### PR TITLE
Implement private client spaces

### DIFF
--- a/docs/CLIENT_SPACES.md
+++ b/docs/CLIENT_SPACES.md
@@ -1,0 +1,21 @@
+# Client Spaces
+
+Este proyecto soporta p\u00e1ginas privadas para clientes en la ruta `/proyecto/:token`.
+Cada cliente se define en `src/data/clientProjects.json` con la siguiente estructura:
+
+```json
+{
+  "token_unico": {
+    "passcode": "codigo",
+    "project": { "nombre": "...", "descripcion": "..." },
+    "cotizaciones": [ { "id": "#001", "titulo": "..." } ]
+  }
+}
+```
+
+Para agregar un nuevo cliente:
+1. A\u00f1ade una entrada en `src/data/clientProjects.json` con un `token` y `passcode`.
+2. Incluye los datos del proyecto y las cotizaciones asociadas.
+3. Comparte la URL `https://www.elelier.com/proyecto/<token>` y el c\u00f3digo de acceso con el cliente.
+
+Las p\u00e1ginas de cliente incluyen etiquetas `noindex` para evitar que aparezcan en buscadores.

--- a/my-app/public/robots.txt
+++ b/my-app/public/robots.txt
@@ -1,5 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /proyecto/
 
 # Sitemap: https://www.elelier.com/sitemap.xml

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -23,6 +23,7 @@ import ChatModal from './components/ChatModal';
 import { FaArrowUp } from 'react-icons/fa';
 import ExternalRedirect from './components/ExternalRedirect';
 import MockupRedirect from './components/MockupRedirect';
+import ClientSpace from './components/ClientSpace';
 
 // Lazy load components
 const Blog = lazy(() => import('./components/Blog'));
@@ -79,6 +80,7 @@ function App({ initialLanguage }) {
                   <Route path="/contacto" element={<Contacto />} />
                   <Route path="/cotizacion/:id" element={<ExternalRedirect />} />
                   <Route path="/mockup/:id" element={<MockupRedirect />} />
+                  <Route path="/proyecto/:token" element={<ClientSpace />} />
                 </Routes>
               </Suspense>
               <Footer />

--- a/my-app/src/components/ClientSpace.jsx
+++ b/my-app/src/components/ClientSpace.jsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+import data from '../data/clientProjects.json';
+import QuoteCard from './QuoteCard';
+import '../styles/components/ClientSpace.css';
+
+const ClientSpace = () => {
+  const { token } = useParams();
+  const client = data[token];
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    if (!client) return;
+    const stored = localStorage.getItem(`client_${token}`);
+    if (stored === client.passcode) {
+      setAuthorized(true);
+      return;
+    }
+    const pass = window.prompt('Ingresa tu c\u00f3digo de acceso');
+    if (pass === client.passcode) {
+      localStorage.setItem(`client_${token}`, pass);
+      setAuthorized(true);
+    }
+  }, [token, client]);
+
+  if (!client) {
+    return <div className="client-space">Cliente no encontrado</div>;
+  }
+
+  if (!authorized) {
+    return <div className="client-space">Acceso denegado</div>;
+  }
+
+  const { project, cotizaciones } = client;
+
+  return (
+    <div className="client-space">
+      <Helmet>
+        <meta name="robots" content="noindex,nofollow" />
+        <link rel="canonical" href="https://www.elelier.com/" />
+      </Helmet>
+      <header className="client-header">
+        <h1>{project.nombre}</h1>
+        <p>{project.descripcion}</p>
+        <p>
+          <strong>{project.cliente}</strong> - {project.fecha}
+        </p>
+      </header>
+      <div className="quote-list">
+        {cotizaciones.map((q) => (
+          <QuoteCard key={q.id} quote={q} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ClientSpace;

--- a/my-app/src/components/QuoteCard.jsx
+++ b/my-app/src/components/QuoteCard.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import '../styles/components/QuoteCard.css';
+
+const statusIcons = {
+  'abierta': '🟢',
+  'en revision': '🟡',
+  'cerrada': '🔴',
+  'aprobada': '✅'
+};
+
+const QuoteCard = ({ quote }) => {
+  const icon = statusIcons[quote.estado] || '';
+  return (
+    <div className="quote-card">
+      <div className="quote-header">
+        <span className="quote-id">{quote.id}</span>
+        <span className="quote-status">{icon}</span>
+      </div>
+      <h4 className="quote-title">{quote.titulo}</h4>
+      <p className="quote-amount">{quote.monto}</p>
+      <p className="quote-time">{quote.tiempoEntrega}</p>
+      <ul className="quote-items">
+        {quote.incluidos && quote.incluidos.map((item, idx) => (
+          <li key={idx}>{item}</li>
+        ))}
+      </ul>
+      {quote.documento && (
+        <a href={`/cotizacion/${quote.documento}`} className="quote-link" target="_blank" rel="noopener noreferrer">
+          Ver Documento →
+        </a>
+      )}
+    </div>
+  );
+};
+
+export default QuoteCard;

--- a/my-app/src/data/clientProjects.json
+++ b/my-app/src/data/clientProjects.json
@@ -1,0 +1,35 @@
+{
+  "token123": {
+    "passcode": "demo123",
+    "project": {
+      "nombre": "Andamios Modulares",
+      "descripcion": "Redise\u00f1o Web B2B para empresa de construcci\u00f3n",
+      "cliente": "Empresa Constructora S.A.",
+      "fecha": "04/2024",
+      "estudio": "IL&EL \u2013 Brand & Product Studio",
+      "industria": "Construcci\u00f3n",
+      "ubicacion": "Monterrey, MX",
+      "numCotizaciones": 2
+    },
+    "cotizaciones": [
+      {
+        "id": "#001",
+        "titulo": "Desarrollo Web",
+        "estado": "abierta",
+        "monto": "$10,000",
+        "tiempoEntrega": "4 semanas",
+        "incluidos": ["\ud83d\udcf1 Dise\u00f1o responsivo", "\ud83d\udee0\ufe0f SEO b\u00e1sico"],
+        "documento": "00132"
+      },
+      {
+        "id": "#002",
+        "titulo": "Mantenimiento",
+        "estado": "cerrada",
+        "monto": "$2,000",
+        "tiempoEntrega": "1 semana",
+        "incluidos": ["\ud83d\udd27 Actualizaciones", "\ud83d\udcca Reportes"],
+        "documento": "00133"
+      }
+    ]
+  }
+}

--- a/my-app/src/styles/components/ClientSpace.css
+++ b/my-app/src/styles/components/ClientSpace.css
@@ -1,0 +1,16 @@
+.client-space {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.client-header {
+  text-align: center;
+}
+
+.quote-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.5rem;
+}

--- a/my-app/src/styles/components/QuoteCard.css
+++ b/my-app/src/styles/components/QuoteCard.css
@@ -1,0 +1,38 @@
+.quote-card {
+  background: var(--color-bg-solid);
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quote-header {
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.quote-title {
+  margin: 0.5rem 0;
+  color: var(--hero-title-color-2);
+}
+
+.quote-amount {
+  text-decoration: line-through;
+  color: var(--color-text);
+}
+
+.quote-link {
+  margin-top: auto;
+  align-self: flex-start;
+  text-decoration: none;
+  color: var(--color-accent);
+  font-weight: 500;
+}
+
+.quote-link:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- add example client data model
- create QuoteCard and ClientSpace components
- update route table to expose `/proyecto/:token`
- prevent indexing of client pages
- document how to add client spaces

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684a38bf638c83328054ed83c4be7fc1