### PR TITLE
Add resumen field to quotes

### DIFF
--- a/docs/CLIENT_SPACES.md
+++ b/docs/CLIENT_SPACES.md
@@ -8,7 +8,9 @@ Cada cliente se define en `src/data/clientProjects.json` con la siguiente estruc
   "token_unico": {
     "passcode": "codigo",
     "project": { "nombre": "...", "descripcion": "..." },
-    "cotizaciones": [ { "id": "#001", "titulo": "..." } ]
+    "cotizaciones": [
+      { "id": "#001", "titulo": "...", "resumen": "Objetivo de la cotización" }
+    ]
   }
 }
 ```

--- a/my-app/src/components/QuoteCard.jsx
+++ b/my-app/src/components/QuoteCard.jsx
@@ -68,6 +68,9 @@ const QuoteCard = ({ quote }) => {
       </div>
       
       <h4 className="quote-title">{quote.titulo}</h4>
+      {quote.resumen && (
+        <p className="quote-summary">{quote.resumen}</p>
+      )}
       <div className="quote-amount">{quote.monto}</div>
       
       <div className="quote-info-grid">

--- a/my-app/src/data/clientProjects.json
+++ b/my-app/src/data/clientProjects.json
@@ -15,6 +15,7 @@
       {
         "id": "#001",
         "titulo": "Desarrollo Web",
+        "resumen": "Objetivo de la cotización",
         "estado": "abierta",
         "monto": "$10,000",
         "tiempoEntrega": "4 semanas",
@@ -26,6 +27,7 @@
       {
         "id": "#002",
         "titulo": "Mantenimiento",
+        "resumen": "Objetivo de la cotización",
         "estado": "cerrada",
         "monto": "$2,000",
         "tiempoEntrega": "1 semana",
@@ -52,6 +54,7 @@
       {
         "id": "#003",
         "titulo": "Desarrollo Frontend",
+        "resumen": "Objetivo de la cotización",
         "estado": "aprobada",
         "monto": "$15,000",
         "tiempoEntrega": "6 semanas",
@@ -63,6 +66,7 @@
       {
         "id": "#004",
         "titulo": "Backend y API",
+        "resumen": "Objetivo de la cotización",
         "estado": "en revision",
         "monto": "$12,000",
         "tiempoEntrega": "5 semanas",
@@ -74,6 +78,7 @@
       {
         "id": "#005",
         "titulo": "Hosting y Dominio",
+        "resumen": "Objetivo de la cotización",
         "estado": "abierta",
         "monto": "$3,000",
         "tiempoEntrega": "1 semana",

--- a/my-app/src/styles/components/QuoteCard.css
+++ b/my-app/src/styles/components/QuoteCard.css
@@ -119,6 +119,17 @@
   line-height: 1.3;
 }
 
+.quote-summary {
+  margin: -0.25rem 0 0.75rem 0;
+  color: #374151;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+[data-theme="dark"] .quote-summary {
+  color: #d1d5db;
+}
+
 [data-theme="dark"] .quote-title {
   color: #f9fafb;
 }
@@ -299,6 +310,10 @@
   
   .quote-title {
     font-size: 1.1rem;
+  }
+
+  .quote-summary {
+    font-size: 0.9rem;
   }
   
   .quote-amount {


### PR DESCRIPTION
## Summary
- expand client project data with a new `resumen` property for each quote
- display that summary in QuoteCard
- style the new summary text
- document the `resumen` field in CLIENT_SPACES.md

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5033b3b48332a5dd435aba72cf5f