### PR TITLE
Reuse CSS variables in client space components

### DIFF
--- a/docs/CLIENT_SPACES.md
+++ b/docs/CLIENT_SPACES.md
@@ -21,3 +21,9 @@ Para agregar un nuevo cliente:
 3. Comparte la URL `https://www.elelier.com/proyecto/<token>` y el c\u00f3digo de acceso con el cliente.
 
 Las p\u00e1ginas de cliente incluyen etiquetas `noindex` para evitar que aparezcan en buscadores.
+
+## Estilos compartidos
+Los componentes de Client Space usan las mismas variables CSS definidas en `src/styles/index.css`.
+Al crear nuevas vistas para un cliente procura reutilizar `var(--color-bg-solid)`,
+`var(--color-border)` y `var(--color-shadow)` para que coincidan con módulos como
+`MockupRedirect` y `ProjectProgress`.

--- a/my-app/src/styles/components/ClientSpace.css
+++ b/my-app/src/styles/components/ClientSpace.css
@@ -4,63 +4,40 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  background: #f8fafc;
-  color: #111827;
-}
-
-/* Dark mode support */
-[data-theme="dark"] .client-space {
-  background: #0f172a;
-  color: #f1f5f9;
+  background: linear-gradient(to bottom, var(--color-bg-3), var(--color-bg));
+  color: var(--color-text);
 }
 
 .client-header {
   text-align: center;
   margin-bottom: 2rem;
   padding: 2.5rem;
-  background: #ffffff;
-  border: 2px solid #e2e8f0;
+  background: var(--color-bg-solid);
+  border: 2px solid var(--color-border);
   border-radius: 16px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-}
-
-[data-theme="dark"] .client-header {
-  background: #1e293b;
-  border-color: #334155;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 12px var(--color-shadow);
 }
 
 .client-header h1 {
-  color: #1e40af;
+  color: var(--hero-title-color);
   font-size: 2.5rem;
   margin-bottom: 1rem;
   font-weight: 800;
   line-height: 1.2;
 }
 
-[data-theme="dark"] .client-header h1 {
-  color: #60a5fa;
-}
 
 .client-header p {
   font-size: 1.1rem;
   margin-bottom: 0.75rem;
   line-height: 1.6;
-  color: #374151;
-}
-
-[data-theme="dark"] .client-header p {
-  color: #d1d5db;
+  color: var(--color-text);
 }
 
 .client-header p:last-child {
-  color: #6b7280;
+  color: var(--color-text-muted);
   font-weight: 500;
   font-size: 0.95rem;
-}
-
-[data-theme="dark"] .client-header p:last-child {
-  color: #9ca3af;
 }
 
 .quote-list {
@@ -79,44 +56,27 @@
   justify-content: center;
   min-height: 60vh;
   text-align: center;
-  background: #ffffff;
-  border: 2px solid #e5e7eb;
+  background: var(--color-bg-solid);
+  border: 2px solid var(--color-border);
   border-radius: 16px;
   padding: 3rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-}
-
-[data-theme="dark"] .client-space .error-message,
-[data-theme="dark"] .client-space .access-denied {
-  background: #1e293b;
-  border-color: #334155;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 12px var(--color-shadow);
 }
 
 .client-space .error-message h2,
 .client-space .access-denied h2 {
-  color: #dc2626;
+  color: var(--color-danger);
   margin-bottom: 1rem;
   font-size: 1.8rem;
   font-weight: 700;
 }
 
-[data-theme="dark"] .client-space .error-message h2,
-[data-theme="dark"] .client-space .access-denied h2 {
-  color: #f87171;
-}
-
 .client-space .error-message p,
 .client-space .access-denied p {
-  color: #374151;
+  color: var(--color-text);
   font-size: 1.1rem;
   line-height: 1.6;
   margin-bottom: 0.5rem;
-}
-
-[data-theme="dark"] .client-space .error-message p,
-[data-theme="dark"] .client-space .access-denied p {
-  color: #d1d5db;
 }
 
 /* Responsive design */

--- a/my-app/src/styles/components/QuoteCard.css
+++ b/my-app/src/styles/components/QuoteCard.css
@@ -1,6 +1,6 @@
 .quote-card {
-  background: #ffffff;
-  border: 2px solid #e5e7eb;
+  background: var(--color-bg-solid);
+  border: 2px solid var(--color-border);
   border-radius: 12px;
   padding: 1.5rem;
   display: flex;
@@ -8,26 +8,15 @@
   gap: 1rem;
   transition: all 0.3s ease;
   position: relative;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 2px 8px var(--color-shadow);
   min-height: 280px;
-}
-
-/* Dark mode support */
-[data-theme="dark"] .quote-card {
-  background: #1f2937;
-  border-color: #374151;
-  color: #f9fafb;
+  color: var(--color-text);
 }
 
 .quote-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-  border-color: #3b82f6;
-}
-
-[data-theme="dark"] .quote-card:hover {
-  border-color: #60a5fa;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 8px 24px var(--color-shadow);
+  border-color: var(--color-accent);
 }
 
 .quote-header {
@@ -40,8 +29,8 @@
 }
 
 .quote-id {
-  background: #3b82f6;
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-bg);
   padding: 0.4rem 0.8rem;
   border-radius: 8px;
   font-weight: 700;
@@ -63,57 +52,33 @@
 }
 
 .quote-status-badge.abierta {
-  background: #dcfce7;
-  color: #166534;
-  border: 1px solid #bbf7d0;
+  background: var(--color-success-bg, #dcfce7);
+  color: var(--color-success-text, #166534);
+  border: 1px solid var(--color-success, #bbf7d0);
 }
 
 .quote-status-badge.cerrada {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  background: var(--color-danger-bg, #fee2e2);
+  color: var(--color-danger-text, #991b1b);
+  border: 1px solid var(--color-danger, #fecaca);
 }
 
 .quote-status-badge.aprobada {
-  background: #dbeafe;
-  color: #1e40af;
-  border: 1px solid #bfdbfe;
+  background: var(--color-info-bg, #dbeafe);
+  color: var(--color-info-text, #1e40af);
+  border: 1px solid var(--color-info, #bfdbfe);
 }
 
 .quote-status-badge[data-status="en revision"] {
-  background: #fef3c7;
-  color: #92400e;
-  border: 1px solid #fed7aa;
+  background: var(--color-warning-bg, #fef3c7);
+  color: var(--color-warning-text, #92400e);
+  border: 1px solid var(--color-warning, #fed7aa);
 }
 
-/* Dark mode status badges */
-[data-theme="dark"] .quote-status-badge.abierta {
-  background: #064e3b;
-  color: #6ee7b7;
-  border-color: #047857;
-}
-
-[data-theme="dark"] .quote-status-badge.cerrada {
-  background: #7f1d1d;
-  color: #fca5a5;
-  border-color: #dc2626;
-}
-
-[data-theme="dark"] .quote-status-badge.aprobada {
-  background: #1e3a8a;
-  color: #93c5fd;
-  border-color: #3b82f6;
-}
-
-[data-theme="dark"] .quote-status-badge[data-status="en revision"] {
-  background: #78350f;
-  color: #fcd34d;
-  border-color: #f59e0b;
-}
 
 .quote-title {
   margin: 0 0 0.5rem 0;
-  color: #111827;
+  color: var(--color-text);
   font-size: 1.25rem;
   font-weight: 700;
   line-height: 1.3;
@@ -121,31 +86,19 @@
 
 .quote-summary {
   margin: -0.25rem 0 0.75rem 0;
-  color: #374151;
+  color: var(--color-text);
   font-size: 0.95rem;
   line-height: 1.5;
-}
-
-[data-theme="dark"] .quote-summary {
-  color: #d1d5db;
-}
-
-[data-theme="dark"] .quote-title {
-  color: #f9fafb;
 }
 
 .quote-amount {
   font-size: 1.5rem;
   font-weight: 800;
-  color: #3b82f6;
+  color: var(--color-accent);
   margin: 0.5rem 0;
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-
-[data-theme="dark"] .quote-amount {
-  color: #60a5fa;
 }
 
 .quote-info-grid {
@@ -156,44 +109,35 @@
 }
 
 .quote-info-item {
-  background: #f8fafc;
+  background: var(--color-bg-alt);
   padding: 0.75rem;
   border-radius: 8px;
-  border-left: 3px solid #e5e7eb;
+  border-left: 3px solid var(--color-border);
   font-size: 0.85rem;
 }
 
-[data-theme="dark"] .quote-info-item {
-  background: #374151;
-  border-left-color: #4b5563;
+.quote-info-item.delivery {
+  border-left-color: var(--color-accent);
 }
 
-.quote-info-item.delivery {
-  border-left-color: #3b82f6;
-}
 
 .quote-info-item.expiration {
-  border-left-color: #ef4444;
+  border-left-color: var(--color-danger);
 }
 
 .quote-info-item.expiration.urgent {
-  background: #fef2f2;
-  border-left-color: #dc2626;
-  color: #991b1b;
-}
-
-[data-theme="dark"] .quote-info-item.expiration.urgent {
-  background: #7f1d1d;
-  color: #fca5a5;
+  background: var(--color-danger-bg, #fef2f2);
+  border-left-color: var(--color-danger);
+  color: var(--color-danger-text, #991b1b);
 }
 
 .quote-info-item.creation {
-  border-left-color: #6b7280;
+  border-left-color: var(--color-border);
 }
 
 .quote-info-label {
   font-weight: 600;
-  color: #6b7280;
+  color: var(--color-text-muted);
   display: block;
   margin-bottom: 0.2rem;
   font-size: 0.75rem;
@@ -201,46 +145,29 @@
   letter-spacing: 0.5px;
 }
 
-[data-theme="dark"] .quote-info-label {
-  color: #9ca3af;
-}
-
 .quote-info-value {
-  color: #111827;
+  color: var(--color-text);
   font-weight: 500;
-}
-
-[data-theme="dark"] .quote-info-value {
-  color: #f3f4f6;
 }
 
 .quote-items {
   list-style: none;
   padding: 0;
   margin: 1rem 0;
-  background: #f8fafc;
+  background: var(--color-bg-alt);
   border-radius: 8px;
   padding: 1rem;
 }
 
-[data-theme="dark"] .quote-items {
-  background: #374151;
-}
-
 .quote-items li {
   padding: 0.5rem 0;
-  border-bottom: 1px solid #e5e7eb;
-  color: #374151;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
   font-size: 0.9rem;
   line-height: 1.4;
   display: flex;
   align-items: center;
   gap: 0.5rem;
-}
-
-[data-theme="dark"] .quote-items li {
-  border-bottom-color: #4b5563;
-  color: #d1d5db;
 }
 
 .quote-items li:last-child {
@@ -250,7 +177,7 @@
 
 .quote-items li::before {
   content: "✓";
-  color: #10b981;
+  color: var(--color-success, #10b981);
   font-weight: bold;
   font-size: 1rem;
   flex-shrink: 0;
@@ -258,8 +185,8 @@
 
 .quote-link {
   margin-top: auto;
-  background: #3b82f6;
-  color: white;
+  background: var(--color-accent);
+  color: var(--color-bg);
   padding: 0.75rem 1.25rem;
   border-radius: 8px;
   text-decoration: none;
@@ -274,15 +201,15 @@
 }
 
 .quote-link:hover {
-  background: #2563eb;
+  background: var(--color-accent);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.4);
+  box-shadow: 0 4px 12px var(--color-shadow);
   text-decoration: none;
-  color: white;
+  color: var(--color-bg);
 }
 
 .quote-link:focus {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--color-accent);
   outline-offset: 2px;
 }
 


### PR DESCRIPTION
## Summary
- refactor ClientSpace styles to rely on global CSS variables
- update QuoteCard styles with the same variables and patterns
- document shared styling approach in CLIENT_SPACES.md

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a514b24648332823f39ec47ee98fb