### PR TITLE
Categorize client projects and quotes

### DIFF
--- a/docs/CLIENT_SPACES.md
+++ b/docs/CLIENT_SPACES.md
@@ -21,3 +21,14 @@ Para agregar un nuevo cliente:
 3. Comparte la URL `https://www.elelier.com/proyecto/<token>` y el c\u00f3digo de acceso con el cliente.
 
 Las p\u00e1ginas de cliente incluyen etiquetas `noindex` para evitar que aparezcan en buscadores.
+
+## Categorías de proyectos y cotizaciones
+
+Los espacios de cliente muestran la información agrupada según el estado del proyecto y de sus cotizaciones:
+
+- **Proyectos Activos**: proyectos cuyo campo `estadoProyecto` es `"activo"`.
+- **Proyectos terminados**: proyectos con `estadoProyecto` igual a `"terminado"`.
+- **Cotizaciones Activas**: cotizaciones vigentes (no expiradas) y sin estado `aprobada` o `cerrada`.
+- **Cotizaciones expiradas**: cotizaciones cuya `fechaExpiracion` ya pasó.
+
+Estas categorías facilitan consultar rápidamente el avance del proyecto y el estado de cada cotización.

--- a/my-app/src/components/ClientSpace.jsx
+++ b/my-app/src/components/ClientSpace.jsx
@@ -58,6 +58,26 @@ const ClientSpace = () => {
 
   const { project, cotizaciones } = client;
 
+  const projectCategory =
+    project.estadoProyecto === 'terminado'
+      ? 'Proyectos terminados'
+      : 'Proyectos Activos';
+
+  const today = new Date();
+  const activeQuotes = [];
+  const expiredQuotes = [];
+
+  cotizaciones.forEach((q) => {
+    const exp = q.fechaExpiracion ? new Date(q.fechaExpiracion) : null;
+    const isExpired = exp && exp < today;
+    const closed = q.estado === 'aprobada' || q.estado === 'cerrada';
+    if (isExpired) {
+      expiredQuotes.push(q);
+    } else if (!closed) {
+      activeQuotes.push(q);
+    }
+  });
+
   return (
     <div className="client-space">
       <Helmet>
@@ -76,12 +96,30 @@ const ClientSpace = () => {
             {project.estudio} | {project.industria} | {project.ubicacion}
           </p>
         )}
+        <p className="project-category">{projectCategory}</p>
       </header>
-      <div className="quote-list">
-        {cotizaciones.map((q) => (
-          <QuoteCard key={q.id} quote={q} />
-        ))}
-      </div>
+
+      {activeQuotes.length > 0 && (
+        <section className="quote-section">
+          <h3>Cotizaciones Activas</h3>
+          <div className="quote-list">
+            {activeQuotes.map((q) => (
+              <QuoteCard key={q.id} quote={q} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {expiredQuotes.length > 0 && (
+        <section className="quote-section">
+          <h3>Cotizaciones Expiradas</h3>
+          <div className="quote-list">
+            {expiredQuotes.map((q) => (
+              <QuoteCard key={q.id} quote={q} />
+            ))}
+          </div>
+        </section>
+      )}
     </div>
   );
 };

--- a/my-app/src/components/QuoteCard.jsx
+++ b/my-app/src/components/QuoteCard.jsx
@@ -1,6 +1,22 @@
 import React from 'react';
 import '../styles/components/QuoteCard.css';
 
+export const isQuoteExpired = (quote) => {
+  if (!quote.fechaExpiracion) return false;
+  return new Date(quote.fechaExpiracion) < new Date();
+};
+
+export const getQuoteCategory = (quote) => {
+  if (isQuoteExpired(quote)) {
+    return 'Cotizaciones expiradas';
+  }
+  const closed = quote.estado === 'aprobada' || quote.estado === 'cerrada';
+  if (!closed) {
+    return 'Cotizaciones Activas';
+  }
+  return null;
+};
+
 const statusIcons = {
   'abierta': '🟢',
   'cerrada': '🔴',
@@ -59,7 +75,7 @@ const QuoteCard = ({ quote }) => {
   };
 
   return (
-    <div className="quote-card" data-status={quote.estado}>
+    <div className={`quote-card ${isExpired ? 'expired' : ''}`} data-status={quote.estado}>
       <div className="quote-header">
         <span className="quote-id">{quote.id}</span>
         <span className={`quote-status-badge ${quote.estado}`} data-status={quote.estado}>

--- a/my-app/src/data/clientProjects.json
+++ b/my-app/src/data/clientProjects.json
@@ -9,7 +9,8 @@
       "estudio": "IL&EL \u2013 Brand & Product Studio",
       "industria": "Construcci\u00f3n",
       "ubicacion": "Monterrey, MX",
-      "numCotizaciones": 2
+      "numCotizaciones": 2,
+      "estadoProyecto": "activo"
     },
     "cotizaciones": [
       {
@@ -48,7 +49,8 @@
       "estudio": "IL&EL – Brand & Product Studio",
       "industria": "Tecnología",
       "ubicacion": "Ciudad de México, MX",
-      "numCotizaciones": 3
+      "numCotizaciones": 3,
+      "estadoProyecto": "terminado"
     },
     "cotizaciones": [
       {

--- a/my-app/src/styles/components/ClientSpace.css
+++ b/my-app/src/styles/components/ClientSpace.css
@@ -70,6 +70,20 @@
   margin-top: 1rem;
 }
 
+.project-category {
+  margin-top: 0.5rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+[data-theme="dark"] .project-category {
+  color: #93c5fd;
+}
+
+.quote-section {
+  margin-bottom: 2rem;
+}
+
 /* Estados de error/loading con mejor contraste */
 .client-space .error-message,
 .client-space .access-denied {

--- a/my-app/src/styles/components/QuoteCard.css
+++ b/my-app/src/styles/components/QuoteCard.css
@@ -12,6 +12,10 @@
   min-height: 280px;
 }
 
+.quote-card.expired {
+  opacity: 0.6;
+}
+
 /* Dark mode support */
 [data-theme="dark"] .quote-card {
   background: #1f2937;


### PR DESCRIPTION
## Summary
- add `estadoProyecto` to each project
- detect expired quotes and expose `getQuoteCategory`
- show project category and quote sections in `ClientSpace`
- style new categories
- document category meanings in `CLIENT_SPACES.md`

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_684a513bf7008332bfdbf343ef4df03e