### PR TITLE
Add client space CTA and contact form prefilling

### DIFF
--- a/my-app/src/components/ClientSpace.jsx
+++ b/my-app/src/components/ClientSpace.jsx
@@ -8,14 +8,29 @@ import UpdatesModal from './UpdatesModal';
 import clientAuthService from '../services/clientAuthService';
 import { hashedPasscodes } from '../config/hashedPasscodes';
 import '../styles/components/ClientSpace.css';
+import { useLanguage } from '../contexts/LanguageContext';
 
 const ClientSpace = () => {
   const { token } = useParams();
+  const { language } = useLanguage();
   const client = data[token];
   const [authorized, setAuthorized] = useState(false);
   const [showUpdatesModal, setShowUpdatesModal] = useState(false);
   const [passcode, setPasscode] = useState('');
   const [error, setError] = useState('');
+
+  const ctaText = {
+    es: {
+      withQuotes: '¿Alguna duda con tus cotizaciones? ',
+      requestQuote: '¿Listo para solicitar una cotización? ',
+      contact: 'Contáctanos'
+    },
+    en: {
+      withQuotes: 'Any questions about your quotes? ',
+      requestQuote: 'Ready to request a quote? ',
+      contact: 'Contact us'
+    }
+  };
 
   const handleSubmitPasscode = async (e) => {
     e.preventDefault();
@@ -366,6 +381,19 @@ const ClientSpace = () => {
           onClose={handleCloseUpdatesModal}
           updates={recentUpdates}
         />
+        <section className="clientspace-cta">
+          {activeQuotes.length > 0 ? (
+            <p>
+              {ctaText[language].withQuotes}
+              <a href="/contacto?subject=quote">{ctaText[language].contact}</a>
+            </p>
+          ) : (
+            <p>
+              {ctaText[language].requestQuote}
+              <a href="/contacto?subject=quote">{ctaText[language].contact}</a>
+            </p>
+          )}
+        </section>
       </div>
     </div>
   );

--- a/my-app/src/components/Contacto.js
+++ b/my-app/src/components/Contacto.js
@@ -1,11 +1,12 @@
 // Contacto.js
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import CV from '../assets/files/2409_CV_EL.pdf';
 import { motion } from 'framer-motion';
 import '../styles/components/Contacto.css';
 import perfilImg from '../assets/images/profile-picture-elier2.png';
+import { useLocation } from 'react-router-dom';
 
 const texts = {
   es: {
@@ -57,6 +58,19 @@ function Contacto() {
   const [message, setMessage] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const location = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('subject') === 'quote' && message === '') {
+      const quoteText =
+        language === 'es'
+          ? 'Hola, me gustaría solicitar una cotización.'
+          : 'Hi, I would like to request a quote.';
+      setMessage(quoteText);
+    }
+  }, [location.search, language]);
+
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/my-app/src/styles/components/ClientSpace.css
+++ b/my-app/src/styles/components/ClientSpace.css
@@ -824,3 +824,31 @@
   }
 
 
+.clientspace-cta {
+  margin: 2rem auto;
+  text-align: center;
+  max-width: 800px;
+}
+
+.clientspace-cta a {
+  display: inline-block;
+  padding: 0.8rem 2rem;
+  border-radius: 30px;
+  border: 2px solid var(--color-primary);
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+.clientspace-cta a:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+@media (max-width: 768px) {
+  .clientspace-cta {
+    margin: 1.5rem auto;
+    padding: 0 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- link to contact page from ClientSpace with CTA
- style CTA section
- prefill contact message when `subject=quote` query is used

## Testing
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2a2e3a508332971ab75298620f27