### PR TITLE
Add contextual CTAs to key portfolio sections

### DIFF
--- a/my-app/src/components/ArsenalHabilidades.js
+++ b/my-app/src/components/ArsenalHabilidades.js
@@ -14,6 +14,23 @@ function ArsenalHabilidades() {
   const [activeIndex, setActiveIndex] = useState(null);
   const { language } = useLanguage();
 
+  const ctaContent = {
+    es: {
+      title: '¿Listo para poner estas habilidades en acción?',
+      description:
+        'Agendemos una sesión para entender tus retos y definir cómo estas capacidades pueden impulsar tu proyecto.',
+      primary: 'Planear mi proyecto',
+      secondary: 'Ver servicios disponibles'
+    },
+    en: {
+      title: 'Ready to put these skills to work?',
+      description:
+        'Let’s schedule a session to understand your challenges and decide how these capabilities can move your project forward.',
+      primary: 'Plan my project',
+      secondary: 'Explore available services'
+    }
+  };
+
   const habilidades = {
     es: [
       {
@@ -165,6 +182,15 @@ function ArsenalHabilidades() {
     setActiveIndex(index === activeIndex ? null : index);
   };
 
+  const scrollToSection = (id) => {
+    const section = document.getElementById(id);
+    if (section) {
+      section.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  const currentCta = ctaContent[language] || ctaContent.es;
+
   return (
     <section id="habilidades" className="arsenal-habilidades">
       <h2 className="titulo-seccion">
@@ -205,6 +231,24 @@ function ArsenalHabilidades() {
             </ul>
           </div>
         ))}
+      </div>
+      <div className="cta-habilidades">
+        <h3>{currentCta.title}</h3>
+        <p>{currentCta.description}</p>
+        <div className="cta-habilidades-buttons">
+          <button
+            className="cta-button-primary"
+            onClick={() => scrollToSection('contacto')}
+          >
+            {currentCta.primary}
+          </button>
+          <button
+            className="cta-button-secondary"
+            onClick={() => scrollToSection('servicios')}
+          >
+            {currentCta.secondary}
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/my-app/src/components/Portafolio.js
+++ b/my-app/src/components/Portafolio.js
@@ -216,6 +216,32 @@ const Portafolio = () => {
     ]
   };
 
+  const ctaContent = {
+    es: {
+      title: '¿Te imaginas tu proyecto en este portafolio?',
+      description:
+        'Trabajemos juntos para diseñar una solución a medida, desde la estrategia hasta la implementación.',
+      primary: 'Solicitar una reunión',
+      secondary: 'Revisar servicios disponibles'
+    },
+    en: {
+      title: 'Ready to see your project featured here?',
+      description:
+        'Let’s craft a tailored solution together—from strategic planning to hands-on implementation.',
+      primary: 'Request a meeting',
+      secondary: 'Review available services'
+    }
+  };
+
+  const currentCta = ctaContent[language] || ctaContent.es;
+
+  const handleScrollToSection = (id) => {
+    const section = document.getElementById(id);
+    if (section) {
+      section.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
   return (
     <section id="portafolio" className="portafolio">
       <h2>{currentLang === 'es' ? 'CARRERA PROFESIONAL' : 'PROFESSIONAL CAREER'}</h2>
@@ -227,7 +253,7 @@ const Portafolio = () => {
       <div className="timeline">
         {(currentLang === 'es' ? proyectos.es : proyectos.en).map((proyecto, idx) => (
           <article key={proyecto.nombre} className={idx % 2 === 0 ? 'left' : 'right'}>
-            <div 
+            <div
               className={`content-wrapper ${activeIndex === idx ? 'expanded' : ''}`}
               onClick={() => setActiveIndex(activeIndex === idx ? null : idx)}
             >
@@ -278,6 +304,24 @@ const Portafolio = () => {
             </div>
           </article>
         ))}
+      </div>
+      <div className="portafolio-cta">
+        <h3>{currentCta.title}</h3>
+        <p>{currentCta.description}</p>
+        <div className="portafolio-cta-buttons">
+          <button
+            className="cta-button-primary"
+            onClick={() => handleScrollToSection('contacto')}
+          >
+            {currentCta.primary}
+          </button>
+          <button
+            className="cta-button-secondary"
+            onClick={() => handleScrollToSection('servicios')}
+          >
+            {currentCta.secondary}
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/my-app/src/styles/App.css
+++ b/my-app/src/styles/App.css
@@ -82,6 +82,54 @@ body, html {
   transition: transform 0.3s ease;
 }
 
+.cta-button-primary,
+.cta-button-secondary {
+  border: none;
+  border-radius: 28px;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 12px 28px;
+  font-size: 1rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background-position 0.6s ease;
+  text-decoration: none;
+}
+
+.cta-button-primary {
+  background: linear-gradient(135deg, #a80c9b, #7bcff8, #00cc99);
+  background-size: 250% 250%;
+  color: #ffffff;
+  box-shadow: 0 10px 20px rgba(168, 12, 155, 0.35);
+}
+
+.cta-button-primary:hover {
+  transform: translateY(-3px);
+  background-position: 100% 0;
+  box-shadow: 0 14px 28px rgba(0, 204, 153, 0.35);
+}
+
+.cta-button-primary:active {
+  transform: scale(0.97);
+  box-shadow: inset 0 4px 10px rgba(0, 0, 0, 0.25);
+}
+
+.cta-button-secondary {
+  background: transparent;
+  color: var(--color-accent);
+  border: 2px solid rgba(var(--color-accent-rgb), 0.7);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.15);
+}
+
+.cta-button-secondary:hover {
+  transform: translateY(-3px);
+  background: rgba(var(--color-accent-rgb), 0.12);
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.18);
+}
+
+.cta-button-secondary:active {
+  transform: scale(0.97);
+  box-shadow: inset 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
 .animate-fade-in {
   animation: fadeIn 1s ease-out;
 }

--- a/my-app/src/styles/components/Habilidades.css
+++ b/my-app/src/styles/components/Habilidades.css
@@ -198,6 +198,53 @@
 .habilidad-header.logistics { background-image: url('../../assets/images/skills/logistics.png'); }
 .habilidad-header.ecommerce { background-image: url('../../assets/images/skills/ecommerce.png'); }
 
+.cta-habilidades {
+  margin-top: 60px;
+  max-width: 960px;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 24px;
+  padding: 40px 24px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.cta-habilidades h3 {
+  font-size: 2rem;
+  margin-bottom: 12px;
+  color: var(--hero-title-color-2);
+}
+
+.cta-habilidades p {
+  font-size: 1.1rem;
+  color: var(--color-text);
+  margin-bottom: 28px;
+  line-height: 1.6;
+}
+
+.cta-habilidades-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 16px;
+}
+
+@media (max-width: 768px) {
+  .cta-habilidades {
+    margin-top: 40px;
+    padding: 32px 20px;
+  }
+
+  .cta-habilidades h3 {
+    font-size: 1.6rem;
+  }
+
+  .cta-habilidades p {
+    font-size: 1rem;
+  }
+}
+
 .habilidad-icono {
   display: none;
 }

--- a/my-app/src/styles/components/Portafolio.css
+++ b/my-app/src/styles/components/Portafolio.css
@@ -182,6 +182,39 @@
   transform: translateX(5px);
 }
 
+.portafolio-cta {
+  margin-top: 60px;
+  max-width: 980px;
+  width: 100%;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 24px;
+  padding: 48px 32px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(8px);
+}
+
+.portafolio-cta h3 {
+  font-size: 2.2rem;
+  color: var(--hero-title-color-2);
+  margin-bottom: 16px;
+}
+
+.portafolio-cta p {
+  color: var(--color-text);
+  font-size: 1.15rem;
+  margin-bottom: 32px;
+  line-height: 1.7;
+}
+
+.portafolio-cta-buttons {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 18px;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .proyectos-grid {
@@ -222,6 +255,19 @@
 
   .proyecto-descripcion {
     font-size: 1rem;
+  }
+
+  .portafolio-cta {
+    margin-top: 40px;
+    padding: 36px 20px;
+  }
+
+  .portafolio-cta h3 {
+    font-size: 1.8rem;
+  }
+
+  .portafolio-cta p {
+    font-size: 1.05rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add bilingual CTA copy and smooth scroll actions to the skills and portfolio sections
- introduce shared CTA button styles for reuse across sections
- style the new CTA blocks so they align with the existing visual design

## Testing
- CI=true npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68fec1a266e483329d6620ba91e07e28