### PR TITLE
feat: add admin leads inbox page

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -26,6 +26,7 @@ import ClientSpace from './components/ClientSpace';
 import ClientDemo from './components/ClientDemo';
 import Sites from './components/Sites';
 import SettingsMenu from './components/SettingsMenu';
+import AdminLeads from './pages/AdminLeads';
 
 // Utilidades
 import { initializeTheme } from './components/utils/themeUtils';
@@ -97,6 +98,8 @@ function App({ initialLanguage }) {
 
                   <Route path="/proyecto/:token" element={<ClientSpace />} />
                   <Route path="/client-demo" element={<ClientDemo />} />
+
+                  <Route path="/admin/leads" element={<AdminLeads />} />
 
                   {/* Agregamos ruta independiente */}
                   <Route path="/sites" element={<Sites simplified={false} />} />

--- a/my-app/src/pages/AdminLeads.jsx
+++ b/my-app/src/pages/AdminLeads.jsx
@@ -1,0 +1,265 @@
+import React, { useMemo, useState } from 'react';
+import '../styles/AdminLeads.css';
+
+const STORAGE_KEY = 'ADMIN_TOKEN';
+const DEFAULT_TIER = 'ALL';
+
+const formatDate = (value) => {
+  if (!value) {
+    return 'Sin fecha';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return parsed.toLocaleString('es-PE', {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+};
+
+const copyText = async (text) => {
+  if (!text) {
+    return;
+  }
+
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+};
+
+const normalizeLeads = (payload) => {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+
+  if (payload && Array.isArray(payload.leads)) {
+    return payload.leads;
+  }
+
+  return [];
+};
+
+const AdminLeads = () => {
+  const [token, setToken] = useState(() => sessionStorage.getItem(STORAGE_KEY) || '');
+  const [tierFilter, setTierFilter] = useState(DEFAULT_TIER);
+  const [companyTypeFilter, setCompanyTypeFilter] = useState('ALL');
+  const [leads, setLeads] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [copiedEmail, setCopiedEmail] = useState('');
+
+  const companyTypes = useMemo(() => {
+    const types = new Set();
+    leads.forEach((lead) => {
+      if (lead.company_type) {
+        types.add(lead.company_type);
+      }
+    });
+
+    return ['ALL', ...Array.from(types)];
+  }, [leads]);
+
+  const filteredLeads = useMemo(() => {
+    return leads.filter((lead) => {
+      const tierMatches =
+        tierFilter === DEFAULT_TIER ||
+        String(lead.tier || '').toUpperCase() === tierFilter;
+      const companyMatches =
+        companyTypeFilter === 'ALL' || lead.company_type === companyTypeFilter;
+
+      return tierMatches && companyMatches;
+    });
+  }, [companyTypeFilter, leads, tierFilter]);
+
+  const handleTokenChange = (event) => {
+    const nextToken = event.target.value;
+    setToken(nextToken);
+    sessionStorage.setItem(STORAGE_KEY, nextToken);
+  };
+
+  const handleCopyEmail = async (email) => {
+    try {
+      await copyText(email);
+      setCopiedEmail(email);
+      setTimeout(() => setCopiedEmail(''), 2000);
+    } catch (copyError) {
+      setError('No se pudo copiar el email.');
+    }
+  };
+
+  const fetchLeads = async () => {
+    if (!token) {
+      setError('Ingresa un token válido para cargar los leads.');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const response = await fetch(
+        `https://leads.elelier.com/api/admin/leads?token=${encodeURIComponent(
+          token
+        )}&limit=50`
+      );
+
+      if (response.status === 401) {
+        setError('Token inválido. Verifica el ADMIN_TOKEN.');
+        setLeads([]);
+        return;
+      }
+
+      if (response.status >= 500) {
+        setError('El servidor tuvo un problema. Intenta nuevamente.');
+        setLeads([]);
+        return;
+      }
+
+      if (!response.ok) {
+        setError('No se pudieron cargar los leads.');
+        setLeads([]);
+        return;
+      }
+
+      const payload = await response.json();
+      setLeads(normalizeLeads(payload));
+    } catch (fetchError) {
+      setError('No se pudo conectar con el servidor.');
+      setLeads([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="admin-leads">
+      <header className="admin-leads__header">
+        <h1>Inbox de leads</h1>
+        <p>Panel interno para revisar los últimos leads registrados.</p>
+      </header>
+
+      <section className="admin-leads__controls">
+        <label className="admin-leads__field">
+          <span>ADMIN_TOKEN</span>
+          <input
+            type="password"
+            value={token}
+            onChange={handleTokenChange}
+            placeholder="Pega tu token"
+          />
+        </label>
+
+        <button
+          type="button"
+          className="admin-leads__button"
+          onClick={fetchLeads}
+          disabled={loading}
+        >
+          {loading ? 'Cargando...' : 'Cargar leads'}
+        </button>
+      </section>
+
+      <section className="admin-leads__filters">
+        <label>
+          Tier
+          <select
+            value={tierFilter}
+            onChange={(event) => setTierFilter(event.target.value)}
+          >
+            <option value="ALL">ALL</option>
+            <option value="HIGH">HIGH</option>
+            <option value="MID">MID</option>
+            <option value="LOW">LOW</option>
+          </select>
+        </label>
+        <label>
+          Company type
+          <select
+            value={companyTypeFilter}
+            onChange={(event) => setCompanyTypeFilter(event.target.value)}
+          >
+            {companyTypes.map((type) => (
+              <option key={type} value={type}>
+                {type}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      {error && <p className="admin-leads__error">{error}</p>}
+
+      <section className="admin-leads__list">
+        {filteredLeads.length === 0 && !loading ? (
+          <p className="admin-leads__empty">No hay leads para mostrar.</p>
+        ) : (
+          filteredLeads.map((lead, index) => (
+            <article className="admin-leads__card" key={lead.email || index}>
+              <header>
+                <div>
+                  <h2>{lead.name || 'Sin nombre'}</h2>
+                  <p className="admin-leads__meta">
+                    {formatDate(lead.created_at)} · Tier {lead.tier || 'N/A'} ·
+                    Score {lead.score ?? 'N/A'}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="admin-leads__copy"
+                  onClick={() => handleCopyEmail(lead.email)}
+                >
+                  {copiedEmail === lead.email ? 'Copiado' : 'Copiar email'}
+                </button>
+              </header>
+              <dl>
+                <div>
+                  <dt>Email</dt>
+                  <dd>{lead.email || 'N/A'}</dd>
+                </div>
+                <div>
+                  <dt>Tipo de empresa</dt>
+                  <dd>{lead.company_type || 'N/A'}</dd>
+                </div>
+                <div>
+                  <dt>Problema</dt>
+                  <dd>{lead.problem || 'N/A'}</dd>
+                </div>
+                <div>
+                  <dt>Presupuesto</dt>
+                  <dd>{lead.budget || 'N/A'}</dd>
+                </div>
+                <div>
+                  <dt>Urgencia</dt>
+                  <dd>{lead.urgency || 'N/A'}</dd>
+                </div>
+                <div>
+                  <dt>URL</dt>
+                  <dd className="admin-leads__url">{lead.page_url || 'N/A'}</dd>
+                </div>
+              </dl>
+            </article>
+          ))
+        )}
+      </section>
+    </main>
+  );
+};
+
+export default AdminLeads;

--- a/my-app/src/styles/AdminLeads.css
+++ b/my-app/src/styles/AdminLeads.css
@@ -1,0 +1,143 @@
+.admin-leads {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 120px 24px 80px;
+  color: #f5f5f5;
+}
+
+.admin-leads__header h1 {
+  margin-bottom: 8px;
+  font-size: 2.2rem;
+}
+
+.admin-leads__header p {
+  margin: 0;
+  color: #b5b5b5;
+}
+
+.admin-leads__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-end;
+  margin: 32px 0 16px;
+}
+
+.admin-leads__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 280px;
+}
+
+.admin-leads__field input,
+.admin-leads__filters select {
+  background: #141414;
+  border: 1px solid #2d2d2d;
+  border-radius: 10px;
+  padding: 10px 12px;
+  color: #f5f5f5;
+}
+
+.admin-leads__button,
+.admin-leads__copy {
+  background: #2b63ff;
+  color: #fff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.admin-leads__button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.admin-leads__button:hover:not(:disabled),
+.admin-leads__copy:hover {
+  transform: translateY(-1px);
+}
+
+.admin-leads__filters {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+.admin-leads__filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 160px;
+}
+
+.admin-leads__error {
+  color: #ff7070;
+  margin-bottom: 16px;
+}
+
+.admin-leads__list {
+  display: grid;
+  gap: 16px;
+}
+
+.admin-leads__card {
+  background: #121212;
+  border: 1px solid #262626;
+  border-radius: 16px;
+  padding: 20px;
+}
+
+.admin-leads__card header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.admin-leads__meta {
+  color: #9f9f9f;
+  margin: 6px 0 0;
+}
+
+.admin-leads__card dl {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px 16px;
+  margin: 0;
+}
+
+.admin-leads__card dt {
+  font-weight: 600;
+  color: #c9c9c9;
+  margin-bottom: 4px;
+}
+
+.admin-leads__card dd {
+  margin: 0;
+  color: #f5f5f5;
+  word-break: break-word;
+}
+
+.admin-leads__url {
+  color: #6ea4ff;
+}
+
+.admin-leads__empty {
+  color: #9f9f9f;
+}
+
+@media (max-width: 720px) {
+  .admin-leads {
+    padding-top: 100px;
+  }
+
+  .admin-leads__card header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a lightweight internal admin panel to review recent leads and speed up manual triage. 
- Authenticate access using the existing `ADMIN_TOKEN` without hardcoding secrets. 
- Keep everything in-app without adding new dependencies. 
- Show lead metadata (created_at, tier, score, contact and company info) and make quick actions like copying emails.

### Description
- Added a new page component `my-app/src/pages/AdminLeads.jsx` that stores the token in `sessionStorage`, fetches leads from `https://leads.elelier.com/api/admin/leads?token=${token}&limit=50`, and implements error handling for 401/500 responses. 
- Implemented client-side filters for `tier` and `company_type`, a formatted `created_at` display, and a `Copiar email` button with clipboard fallback. 
- Added styles in `my-app/src/styles/AdminLeads.css` to match the app look and feel. 
- Registered the new route `/admin/leads` in `my-app/src/App.js` so the page is reachable in the SPA.

### Testing
- Attempted to run the dev server with `npm start`, which began but the build failed to compile due to an unrelated missing dependency `react-lazy-load-image-component` in existing components. 
- Executed an automated Playwright script to open `http://127.0.0.1:3000/admin/leads` and capture a screenshot, which produced an artifact for review. 
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696270cc89148332b4a1c0d0d44c25c6)