### PR TITLE
feat: refocus portfolio conversion funnel

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -4,8 +4,6 @@ import { ThemeProvider } from './contexts/ThemeContext';
 import { HelmetProvider } from 'react-helmet-async';
 import React, { useEffect, lazy, Suspense } from 'react';
 import { FaArrowUp } from 'react-icons/fa';
-
-// Componentes principales
 import './styles/App.css';
 import SEO from './components/SEO';
 import Navegacion from './components/Navegacion';
@@ -31,18 +29,14 @@ import GraciasAgenda from './pages/GraciasAgenda';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import TermsOfService from './pages/TermsOfService';
 import AionLabs from './components/AionLabs';
-
-// Utilidades
 import { initializeTheme } from './components/utils/themeUtils';
 import { loadExternalScripts } from './components/utils/generalUtils';
-
-// Debug tools (solo en desarrollo)
 import './utils/testGemini';
+
 if (process.env.NODE_ENV === 'development') {
   import('./debug-gemini');
 }
 
-// Lazy load components
 const Blog = lazy(() => import('./components/Blog'));
 const Entrada = lazy(() => import('./components/entradas/entrada1'));
 
@@ -75,10 +69,7 @@ function App({ initialLanguage }) {
   }, [initialLanguage]);
 
   const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth'
-    });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   return (
@@ -88,22 +79,14 @@ function App({ initialLanguage }) {
           <Router>
             <div className="App">
               <SettingsMenu />
-              <SEO 
-                title="Elier Loya - Transformando Negocios con Tecnología e Innovación" 
+              <SEO
+                title="Elier Loya - Transformando Negocios con Tecnología e Innovación"
                 description="Portafolio de Elier Loya, especialista en transformación digital, e-commerce y optimización de operaciones."
               />
               <Navegacion />
               <Suspense fallback={<div>Loading...</div>}>
                 <Routes>
-                  <Route path="/" element={
-                    <>
-                      {homeSections.map(({ key, Component }, index) => (
-                        <Component key={key} style={getSectionTransitionStyle(index)} />
-                      ))}
-                      {/* Temporalmente oculto mientras se cargan las imágenes
-                      <Sites simplified={true} /> */}
-                    </>
-                  } />
+                  <Route path="/" element={<>{homeSections.map(({ key, Component }, index) => (<Component key={key} style={getSectionTransitionStyle(index)} />))}</>} />
                   <Route path="/tarifas-2024" element={<Tarifario />} />
                   <Route path="/hero-banner" element={<HeroBanner />} />
                   <Route path="/portafolio" element={<Portafolio />} />
@@ -118,6 +101,7 @@ function App({ initialLanguage }) {
                   <Route path="/client-demo" element={<ClientDemo />} />
                   <Route path="/admin/leads" element={<AdminLeads />} />
                   <Route path="/gracias-agenda" element={<GraciasAgenda />} />
+                  <Route path="/gracias-diagnostico" element={<GraciasAgenda />} />
                   <Route path="/privacy-policy" element={<PrivacyPolicy />} />
                   <Route path="/terms-of-service" element={<TermsOfService />} />
                   <Route path="/aionlabs" element={<AionLabs />} />
@@ -125,11 +109,7 @@ function App({ initialLanguage }) {
                 </Routes>
               </Suspense>
               <Footer />
-              <FloatingButton 
-                icon={<FaArrowUp />} 
-                onClick={scrollToTop}
-                ariaLabel="Volver arriba"
-              />
+              <FloatingButton icon={<FaArrowUp />} onClick={scrollToTop} ariaLabel="Volver arriba" />
               <ChatModal />
             </div>
           </Router>

--- a/my-app/src/components/HeroBanner.js
+++ b/my-app/src/components/HeroBanner.js
@@ -10,54 +10,49 @@ const DynamicHeroBanner = ({ style }) => {
   const { language } = useLanguage();
   const { currentTheme } = useContext(ThemeContext);
 
-  // Contenido del banner
   const heroContent = useMemo(() => ({
     es: [
       {
-        title: "Estrategia · Producto · Desarrollo",
-        subtitle: "Digital Product Owner @ CHUBB · Side projects seleccionados",
-        description: "Producto, optimización y experimentación aplicada. Llevo ideas pequeñas a algo tangible sin ruido innecesario.",
-        icon: "🧪",
-        cta: "Contactar"
+        title: 'Llevo tu idea de negocio a un producto digital funcional en semanas, no meses',
+        subtitle: 'Ex-COO de GoFarma y Digital Product Owner en CHUBB. Solo tomo proyectos con foco.',
+        description: 'Estrategia, prototipo y métricas reales para validar, automatizar o destrabar un reto operativo sin humo.',
+        icon: '🧪',
+        cta: 'Recibe diagnóstico exprés'
       }
     ],
     en: [
       {
-        title: "Strategy · Product · Development",
-        subtitle: "Digital Product Owner @ CHUBB · Select side projects",
-        description: "Product, optimization and practical experimentation. I shape small ideas into tangible, low‑noise outputs.",
-        icon: "🧪",
-        cta: "Contact"
+        title: 'I turn your business idea into a working digital product in weeks, not months',
+        subtitle: 'Ex-COO at GoFarma and Digital Product Owner at CHUBB. I only take focused projects.',
+        description: 'Strategy, prototype and real metrics to validate, automate or unblock an operational challenge without fluff.',
+        icon: '🧪',
+        cta: 'Get an express diagnosis'
       }
     ]
   }), []);
 
-  const moreAboutMeText = useMemo(() => ({ es: "Más sobre mí", en: "More about me" }), []);
+  const moreAboutMeText = useMemo(() => ({ es: 'Más sobre mí', en: 'More about me' }), []);
   const currentHeroContent = useMemo(() => heroContent[language], [heroContent, language]);
   const currentContent = currentHeroContent[currentIndex];
 
-  // Cambiar banner automáticamente cada 10 segundos
-  // Desactivar rotación cuando solo hay un bloque
   useEffect(() => {
-    if (currentHeroContent.length <= 1) return; // no rotation
+    if (currentHeroContent.length <= 1) return;
     const timer = setInterval(() => {
       setIsTransitioning(true);
       setTimeout(() => {
         setCurrentIndex((prev) => (prev + 1) % currentHeroContent.length);
         setIsTransitioning(false);
       }, 500);
-    }, 25000); // ritmo más lento si en el futuro se añaden variantes
+    }, 25000);
     return () => clearInterval(timer);
   }, [currentHeroContent.length]);
 
-  // Manejar scroll para animaciones
   useEffect(() => {
     const handleScroll = () => setScrollPosition(window.pageYOffset);
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
-  // Efecto de estrellas en tema oscuro
   useEffect(() => {
     const canvas = document.getElementById('star-canvas');
     if (!canvas) return;
@@ -119,7 +114,7 @@ const DynamicHeroBanner = ({ style }) => {
         <h2 className="hero-title shiny">{currentContent?.title}</h2>
         <h3 className="hero-subtitle">{currentContent?.subtitle}</h3>
         <p className="hero-description">{currentContent?.description}</p>
-        <button className="hero-button" onClick={() => scrollToSection('contacto')}>
+        <button className="hero-button" onClick={() => scrollToSection('diagnostico')}>
           {currentContent?.cta} →
         </button>
       </div>

--- a/my-app/src/components/LeadQualifier.jsx
+++ b/my-app/src/components/LeadQualifier.jsx
@@ -1,37 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import '../styles/components/LeadQualifier.css';
 
 const initialFormState = {
   name: '',
   email: '',
-  companyType: '',
+  companyType: 'pyme',
   problem: '',
   budget: '',
   urgency: '',
+  expectedOutcome: '',
   website: '',
 };
-
-const defaultFollowupQuestions = [
-  {
-    id: 'primaryMetric',
-    labelKey: 'leadFollowupMetric',
-    type: 'select',
-    optionKeys: ['leadFollowupConversion', 'leadFollowupCosts', 'leadFollowupLeadTime', 'leadFollowupRetention', 'leadFollowupOther'],
-  },
-  {
-    id: 'dataAvailable',
-    labelKey: 'leadFollowupData',
-    type: 'select',
-    optionKeys: ['leadFollowupYes', 'leadFollowupNo'],
-  },
-  {
-    id: 'decisionMaker',
-    labelKey: 'leadFollowupDecision',
-    type: 'select',
-    optionKeys: ['leadFollowupMe', 'leadFollowupPartner', 'leadFollowupBoard', 'leadFollowupOther'],
-  },
-];
 
 const buildCalUrl = ({ name, email, clientLeadId, utm, baseUrl }) => {
   const url = new URL(baseUrl || 'https://cal.com/elelier/diagnostico');
@@ -49,35 +30,22 @@ const buildCalUrl = ({ name, email, clientLeadId, utm, baseUrl }) => {
 
 function LeadQualifier({ style }) {
   const { translate } = useLanguage();
+  const navigate = useNavigate();
   const [formData, setFormData] = useState(initialFormState);
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState(null);
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [success, setSuccess] = useState(false);
-  const [followupAnswers, setFollowupAnswers] = useState({});
   const [redirecting, setRedirecting] = useState(false);
   const resultRef = useRef(null);
   const calendarOpenedRef = useRef(false);
-
-  const followupQuestions =
-    result?.tier === 'MID' && Array.isArray(result?.nextStep?.questions) && result.nextStep.questions.length > 0
-      ? result.nextStep.questions
-      : result?.tier === 'MID'
-        ? defaultFollowupQuestions
-        : [];
 
   useEffect(() => {
     if ((result || error) && resultRef.current) {
       resultRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
   }, [result, error]);
-
-  useEffect(() => {
-    if (result?.tier !== 'MID') {
-      setFollowupAnswers({});
-    }
-  }, [result]);
 
   const openCalendar = (leadData, baseUrl) => {
     if (calendarOpenedRef.current) return;
@@ -91,18 +59,12 @@ function LeadQualifier({ style }) {
       baseUrl,
     });
 
-    console.debug('[Cal.com] Opening with params:', finalUrl);
     window.open(finalUrl, '_blank', 'noopener,noreferrer');
   };
 
   const handleChange = (event) => {
     const { name, value } = event.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const handleFollowupChange = (event) => {
-    const { name, value } = event.target;
-    setFollowupAnswers((prev) => ({ ...prev, [name]: value }));
   };
 
   const trackLead = (data) => {
@@ -117,12 +79,9 @@ function LeadQualifier({ style }) {
   };
 
   const submitLead = async (payload) => {
-    if (loading) return null;
-
-    if (redirecting) return null;
+    if (loading || redirecting) return null;
 
     calendarOpenedRef.current = false;
-
     setLoading(true);
     setError(false);
     setErrorMessage('');
@@ -157,11 +116,7 @@ function LeadQualifier({ style }) {
       });
 
       if (!response.ok) {
-        if (response.status === 429) {
-          setErrorMessage(translate('leadTooFast'));
-        } else {
-          setErrorMessage(translate('leadError'));
-        }
+        setErrorMessage(response.status === 429 ? translate('leadTooFast') : translate('leadError'));
         setError(true);
         return null;
       }
@@ -169,25 +124,30 @@ function LeadQualifier({ style }) {
       const data = await response.json();
       setResult(data);
       setSuccess(true);
+
       if (data?.tier && typeof data?.score === 'number') {
         trackLead(data);
       }
 
-      const isHigh = data?.ok && data?.tier === 'HIGH';
       const hasHoneypot = Boolean(trackedPayload.website);
+      if (!hasHoneypot) {
+        const baseUrl = data?.nextStep?.url || 'https://cal.com/elelier/diagnostico';
+        const calUrl = buildCalUrl({
+          name: trackedPayload.name,
+          email: trackedPayload.email,
+          clientLeadId: trackedPayload.clientLeadId,
+          utm: trackedPayload.utm,
+          baseUrl,
+        });
 
-      if (isHigh && !hasHoneypot) {
-        if (!trackedPayload.clientLeadId) {
-          setErrorMessage('No pudimos generar tu ID, intenta de nuevo.');
-          setError(true);
-          return data;
+        sessionStorage.setItem('elelierLastDiagnosisCalUrl', calUrl);
+        setRedirecting(true);
+
+        if (data?.tier === 'HIGH') {
+          openCalendar(trackedPayload, baseUrl);
         }
 
-        const baseUrl = data?.nextStep?.url || 'https://cal.com/elelier/diagnostico';
-        calendarOpenedRef.current = false;
-        setRedirecting(true);
-        openCalendar(trackedPayload, baseUrl);
-        setTimeout(() => setRedirecting(false), 4500);
+        navigate('/gracias-diagnostico');
       }
 
       return data;
@@ -204,25 +164,6 @@ function LeadQualifier({ style }) {
     event.preventDefault();
     await submitLead(formData);
   };
-
-  const handleFollowupSubmit = async (event) => {
-    event.preventDefault();
-
-    const answers = followupQuestions.map((question) => ({
-      id: question.id,
-      label: question.label,
-      value: followupAnswers[question.id] || '',
-    }));
-
-    await submitLead({
-      ...formData,
-      followupAnswers: answers,
-    });
-  };
-
-  const isFollowupReady =
-    followupQuestions.length > 0 &&
-    followupQuestions.every((question) => Boolean(followupAnswers[question.id]));
 
   return (
     <section id="diagnostico" className="lead-qualifier" style={style}>
@@ -245,15 +186,16 @@ function LeadQualifier({ style }) {
               tabIndex={-1}
             />
           </div>
+
           <div className="lead-qualifier__field">
-            <label htmlFor="lead-name">{translate('leadName')}</label>
+            <label htmlFor="lead-name">{translate('leadNameCompany')}</label>
             <input
               id="lead-name"
               name="name"
               type="text"
               value={formData.name}
               onChange={handleChange}
-              autoComplete="name"
+              autoComplete="organization"
               required
             />
           </div>
@@ -271,42 +213,20 @@ function LeadQualifier({ style }) {
             />
           </div>
 
-          <div className="lead-qualifier__field">
-            <label htmlFor="lead-company-type">{translate('leadCompanyType')}</label>
-            <select
-              id="lead-company-type"
-              name="companyType"
-              value={formData.companyType}
-              onChange={handleChange}
-              required
-            >
-              <option value="" disabled>
-                {translate('leadSelectOption')}
-              </option>
-              <option value="freelancer">{translate('leadFreelancer')}</option>
-              <option value="startup">{translate('leadStartup')}</option>
-              <option value="pyme">{translate('leadPyme')}</option>
-              <option value="enterprise">{translate('leadEnterprise')}</option>
-            </select>
-          </div>
+          <fieldset className="lead-qualifier__fieldset">
+            <legend>{translate('leadProblem')}</legend>
+            <label><input type="radio" name="problem" value="validar-idea" checked={formData.problem === 'validar-idea'} onChange={handleChange} required /> {translate('leadValidateIdea')}</label>
+            <label><input type="radio" name="problem" value="optimizar-proceso" checked={formData.problem === 'optimizar-proceso'} onChange={handleChange} /> {translate('leadOptimizeProcess')}</label>
+            <label><input type="radio" name="problem" value="automatizar-ia" checked={formData.problem === 'automatizar-ia'} onChange={handleChange} /> {translate('leadAutomateAI')}</label>
+            <label><input type="radio" name="problem" value="otro" checked={formData.problem === 'otro'} onChange={handleChange} /> {translate('leadOther')}</label>
+          </fieldset>
 
-          <div className="lead-qualifier__field">
-            <label htmlFor="lead-problem">{translate('leadProblem')}</label>
-            <select
-              id="lead-problem"
-              name="problem"
-              value={formData.problem}
-              onChange={handleChange}
-              required
-            >
-              <option value="" disabled>
-                {translate('leadSelectOption')}</option>
-              <option value="operacion">Operacion</option>
-              <option value="producto">Producto</option>
-              <option value="ia">IA</option>
-              <option value="web">Web</option>
-            </select>
-          </div>
+          <fieldset className="lead-qualifier__fieldset">
+            <legend>{translate('leadUrgency')}</legend>
+            <label><input type="radio" name="urgency" value="30-dias" checked={formData.urgency === '30-dias'} onChange={handleChange} required /> {translate('leadNext30Days')}</label>
+            <label><input type="radio" name="urgency" value="trimestre" checked={formData.urgency === 'trimestre'} onChange={handleChange} /> {translate('leadThisQuarter')}</label>
+            <label><input type="radio" name="urgency" value="explorando" checked={formData.urgency === 'explorando'} onChange={handleChange} /> {translate('leadExploring')}</label>
+          </fieldset>
 
           <div className="lead-qualifier__field">
             <label htmlFor="lead-budget">{translate('leadBudget')}</label>
@@ -317,36 +237,33 @@ function LeadQualifier({ style }) {
               onChange={handleChange}
               required
             >
-              <option value="" disabled>
-                {translate('leadSelectOption')}
-              </option>
-              <option value="<3k">{'<3k'}</option>
-              <option value="3-5k">3-5k</option>
-              <option value="5-10k">5-10k</option>
-              <option value="10k+">10k+</option>
+              <option value="" disabled>{translate('leadSelectOption')}</option>
+              <option value="<1k">{translate('leadBudgetUnder1k')}</option>
+              <option value="1-3k">$1k-$3k</option>
+              <option value="3-10k">$3k-$10k</option>
+              <option value="unknown">{translate('leadBudgetUnknown')}</option>
             </select>
           </div>
 
           <div className="lead-qualifier__field">
-            <label htmlFor="lead-urgency">{translate('leadUrgency')}</label>
+            <label htmlFor="lead-expected-outcome">{translate('leadExpectedOutcome')}</label>
             <select
-              id="lead-urgency"
-              name="urgency"
-              value={formData.urgency}
+              id="lead-expected-outcome"
+              name="expectedOutcome"
+              value={formData.expectedOutcome}
               onChange={handleChange}
               required
             >
-              <option value="" disabled>
-                {translate('leadSelectOption')}
-              </option>
-              <option value="2w">2w</option>
-              <option value="1m">1m</option>
-              <option value="3m">3m</option>
+              <option value="" disabled>{translate('leadSelectOption')}</option>
+              <option value="prototipo">{translate('leadOutcomePrototype')}</option>
+              <option value="automatizacion">{translate('leadOutcomeAutomation')}</option>
+              <option value="metricas">{translate('leadOutcomeMetrics')}</option>
+              <option value="claridad">{translate('leadOutcomeClarity')}</option>
             </select>
           </div>
 
           <button className="lead-qualifier__submit" type="submit" disabled={loading || redirecting}>
-            {redirecting ? translate('leadCalendarOpened') : loading ? translate('leadAnalyzing') : translate('leadSubmitButton')}
+            {redirecting ? translate('leadRedirecting') : loading ? translate('leadAnalyzing') : translate('leadSubmitButton')}
           </button>
         </form>
 
@@ -356,88 +273,7 @@ function LeadQualifier({ style }) {
               {errorMessage || translate('leadError')}
             </p>
           )}
-          {result?.ok && result.tier === 'HIGH' && (
-            <div className="lead-qualifier__next-step">
-              <h3>{translate('leadHighTitle')}</h3>
-              <p>{translate('leadHighDescription')}</p>
-              {result?.nextStep?.url && (
-                <a
-                  className="lead-qualifier__action"
-                  href={result.nextStep.url}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {translate('leadHighAction')}
-                </a>
-              )}
-            </div>
-          )}
-          {result?.ok && result.tier === 'MID' && (
-            <div className="lead-qualifier__next-step">
-              <h3>{translate('leadMidTitle')}</h3>
-              <p>{translate('leadMidDescription')}</p>
-              <form className="lead-qualifier__followup-form" onSubmit={handleFollowupSubmit}>
-                {followupQuestions.map((question) => (
-                  <div className="lead-qualifier__field" key={question.id}>
-                    <label htmlFor={`followup-${question.id}`}>
-                      {question.labelKey ? translate(question.labelKey) : question.label}
-                    </label>
-                    {Array.isArray(question.optionKeys || question.options) ? (
-                      <select
-                        id={`followup-${question.id}`}
-                        name={question.id}
-                        value={followupAnswers[question.id] || ''}
-                        onChange={handleFollowupChange}
-                        required
-                      >
-                        <option value="" disabled>
-                          {translate('leadSelectOption')}
-                        </option>
-                        {(question.optionKeys || question.options).map((option) => (
-                          <option key={option} value={translate(option) || option}>
-                            {translate(option) || option}
-                          </option>
-                        ))}
-                      </select>
-                    ) : (
-                      <input
-                        id={`followup-${question.id}`}
-                        name={question.id}
-                        type="text"
-                        value={followupAnswers[question.id] || ''}
-                        onChange={handleFollowupChange}
-                        required
-                      />
-                    )}
-                  </div>
-                ))}
-                <button
-                  className="lead-qualifier__submit"
-                  type="submit"
-                  disabled={loading || redirecting || !isFollowupReady}
-                >
-                  {loading || redirecting ? translate('leadMidProcessing') : translate('leadMidSubmitButton')}
-                </button>
-              </form>
-            </div>
-          )}
-          {result?.ok && result.tier === 'LOW' && (
-            <div className="lead-qualifier__next-step">
-              <h3>{translate('leadLowTitle')}</h3>
-              <p>{translate('leadLowDescription')}</p>
-              {result?.nextStep?.url && (
-                <a
-                  className="lead-qualifier__action"
-                  href={result.nextStep.url}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {translate('leadLowAction')}
-                </a>
-              )}
-            </div>
-          )}
-          {success && result?.ok && !result?.tier && (
+          {success && result?.ok && (
             <p className="lead-qualifier__success">{translate('leadSuccessGeneric')}</p>
           )}
         </div>

--- a/my-app/src/components/Servicios.js
+++ b/my-app/src/components/Servicios.js
@@ -7,52 +7,52 @@ function Servicios({ style }) {
 
   const content = {
     es: {
-      heading: 'Disponibilidad',
-      intro: 'Proyectos pequeños y colaboraciones (10–20 h/semana). Si encaja, escríbeme.',
+      heading: 'Mi método',
+      intro: 'Filtro sin rodeos: trabajo mejor con retos acotados, métricas claras y entregas visibles.',
       blocks: [
         {
-          title: 'Qué sí hago',
-          items: ['Landing page enfocada', 'Prototipo funcional temprano', 'Mejora incremental de un módulo', 'Refactor pequeño con objetivo claro', 'Asesoría técnica puntual (orientación / criterio)']
+          title: '1. Diagnóstico exprés',
+          items: ['Sesión inicial de hasta 1 hora', 'Entender reto, urgencia y restricciones', 'Separar idea vaga de oportunidad accionable']
         },
         {
-          title: 'Qué no tomo',
-          items: ['Proyectos urgentes o “para ayer”', 'Re-escrituras completas sin validación previa', 'Procesos largos de consultoría', 'Roadmaps indefinidos sin foco', 'Marketing vapor / buzzwords']
+          title: '2. Alcance fijo',
+          items: ['Propuesta con entregables concretos', 'Precio transparente antes de construir', 'Criterios de éxito desde el inicio']
         },
         {
-          title: 'Cómo trabajo',
-          items: ['Alcance reducido y explícito', 'Iteraciones visibles antes de seguir', 'Preferencia por simplicidad mantenible', 'Documentar decisiones clave', 'Solo compromisos que realmente cumplo']
+          title: '3. Iteraciones cada 2 semanas',
+          items: ['Avances visibles, no promesas eternas', 'Feedback rápido y ajuste de prioridad', 'Documentación ligera para mantener continuidad']
         },
         {
-          title: 'Ejemplos típicos',
-          items: ['MVP de formulario + listado', 'Página de producto validando propuesta', 'Pequeña API proxy / wrapper', 'Optimización de performance puntual', 'UI refactor: limpiar componentes']
+          title: 'Proyectos ideales',
+          items: ['Validaciones de idea', 'Automatizaciones pequeñas', 'Mejoras de performance', 'MVPs acotados', 'Procesos atascados por maraña técnica o estratégica']
         }
       ],
-      cta: 'Hablemos',
-      ctaHelper: 'Cuéntame el mínimo necesario para evaluar.'
+      cta: 'Recibe diagnóstico exprés',
+      ctaHelper: 'No tomo proyectos sin foco; sí tomo problemas que podemos mover rápido.'
     },
     en: {
-      heading: 'Availability',
-      intro: 'Small projects and collaborations (10–20 h/week). If it fits, get in touch.',
+      heading: 'My method',
+      intro: 'Clear filter: I work best with scoped challenges, clear metrics and visible delivery.',
       blocks: [
         {
-          title: 'What I do',
-          items: ['Focused landing page', 'Early functional prototype', 'Incremental module improvement', 'Small purposeful refactor', 'Targeted technical advisory']
+          title: '1. Express diagnosis',
+          items: ['Initial session up to 1 hour', 'Understand challenge, urgency and constraints', 'Separate vague idea from actionable opportunity']
         },
         {
-          title: 'What I decline',
-          items: ['“Urgent yesterday” projects', 'Full rewrites without prior validation', 'Lengthy consulting programs', 'Vague endless roadmaps', 'Buzzword-driven fluff']
+          title: '2. Fixed scope',
+          items: ['Proposal with concrete deliverables', 'Transparent price before building', 'Success criteria from day one']
         },
         {
-          title: 'How I operate',
-          items: ['Reduced, explicit scope', 'Visible iteration before expanding', 'Bias for maintainable simplicity', 'Document key decisions', 'Only commitments I can honor']
+          title: '3. 2-week iterations',
+          items: ['Visible progress, not endless promises', 'Fast feedback and priority adjustment', 'Light documentation for continuity']
         },
         {
-          title: 'Typical examples',
-          items: ['Form + list MVP', 'Product page validating proposition', 'Small API proxy / wrapper', 'Targeted performance tweak', 'UI cleanup / component pruning']
+          title: 'Ideal projects',
+          items: ['Idea validation', 'Small automations', 'Performance improvements', 'Scoped MVPs', 'Projects stuck in technical or strategic complexity']
         }
       ],
-      cta: 'Start conversation',
-      ctaHelper: 'Share just enough context to assess.'
+      cta: 'Get express diagnosis',
+      ctaHelper: 'I do not take unfocused projects; I do take problems we can move quickly.'
     }
   };
 
@@ -61,7 +61,7 @@ function Servicios({ style }) {
   return (
     <section id="disponibilidad" className="servicios colaboraciones disponibilidad" style={style}>
       <div className="servicios-header">
-        <h1>{/* title */}{t.heading}</h1>
+        <h1>{t.heading}</h1>
       </div>
       <p className="introduccion shinyh">{t.intro}</p>
       <div className="servicios-grid simple-grid">
@@ -69,13 +69,13 @@ function Servicios({ style }) {
           <div key={idx} className="servicio-card minimal">
             <h3>{block.title}</h3>
             <ul className="bullet-clean">
-              {block.items.map((it,i)=>(<li key={i}>{it}</li>))}
+              {block.items.map((it, i) => (<li key={i}>{it}</li>))}
             </ul>
           </div>
         ))}
       </div>
       <div className="servicio-cta global-cta">
-        <button className="cta-button-3" onClick={() => document.getElementById('contacto')?.scrollIntoView({behavior:'smooth'})}>{t.cta}</button>
+        <button className="cta-button-3" onClick={() => document.getElementById('diagnostico')?.scrollIntoView({ behavior: 'smooth' })}>{t.cta}</button>
         <div className="cta-helper-text">{t.ctaHelper}</div>
       </div>
     </section>

--- a/my-app/src/components/SobreMi.js
+++ b/my-app/src/components/SobreMi.js
@@ -15,215 +15,125 @@ function SobreMi({ style }) {
   const sections = useMemo(() => ({
     es: [
       {
-        title: 'Historia Personal',
+        title: 'Resultados',
         image: personal_story,
-        alt: 'Historia Personal',
-        subtitle: 'Desde que tengo memoria, siempre he sentido una gran curiosidad por cómo funcionan las cosas.',
+        alt: 'Elier Loya',
+        subtitle: 'He pasado de coordinar operaciones en PepsiCo a co-fundar una startup con 99.8% de precisión de inventario.',
         content: (
-          <>
-            <div className="content-container">
-              <div className="image-container">
-                <LazyLoadImage
-                  src={personal_story}
-                  alt="Historia Personal"
-                  width={500}
-                  height={500}
-                  effect="blur"
-                  placeholderSrc={personal_story}
-                  className="optimized-image"
-                />
-              </div>
-              <div className="text-content">
-                <p>
-                  Esa misma curiosidad me impulsó a desmontar juguetes, adentrarme en la ingeniería y, con el tiempo, liderar transformaciones tecnológicas en diversas empresas.
-                </p>
-                <p>
-                  Soy Elier Loya, Ingeniero Industrial y de Sistemas con más de una década de experiencia en dirección y optimización de operaciones. Mi pasión por la tecnología y la innovación me impulsó a especializarme en transformación digital y gestión logística.
-                </p>
-                <p>
-                  A lo largo de mi carrera, he liderado transformaciones clave en empresas como GoFarma, Farmalisto y PepsiCo. Actualmente, en CHUBB, aplico mi experiencia para impulsar la transformación digital en el área de renovaciones, potenciando la automatización y personalización de procesos críticos.
-                </p>
-              </div>
+          <div className="content-container">
+            <div className="image-container">
+              <LazyLoadImage src={personal_story} alt="Elier Loya" width={500} height={500} effect="blur" placeholderSrc={personal_story} className="optimized-image" />
             </div>
-          </>
+            <div className="text-content">
+              <p>Combino criterio operativo, pensamiento de producto y ejecución técnica para sacar proyectos de la maraña estratégica o tecnológica.</p>
+              <p>Si tienes una idea validable, un proceso trabado o una automatización que podría mover ingresos, costos o velocidad, yo lo bajo a alcance, prototipo y métrica.</p>
+              <p><strong>Si tu proyecto está atascado, lo desatascamos con foco.</strong></p>
+            </div>
+          </div>
         ),
       },
       {
-        title: 'Experiencia Destacada',
+        title: 'Datos duros',
         image: professional,
-        alt: 'Experiencia Destacada',
-        subtitle: 'Mis logros reflejan mi compromiso con la excelencia operativa y mi pasión por transformar empresas.',
+        alt: 'Resultados profesionales',
+        subtitle: '+10 años transformando operaciones, productos digitales y canales comerciales.',
         content: (
-          <>
-            <div className="content-container">
-              <div className="image-container">
-                <LazyLoadImage
-                  src={professional}
-                  alt="Experiencia Destacada"
-                  width={500}
-                  height={500}
-                  effect="blur"
-                  placeholderSrc={professional}
-                  className="optimized-image"
-                />
-              </div>
-              <div className="text-content">
-                <h3>CHUBB</h3>
-                <p>
-                  Actualmente, como Digital Product Owner en CHUBB, lidero la transformación digital del área de renovaciones de pólizas, impulsando la automatización y personalización de procesos críticos para mejorar la experiencia del cliente y la eficiencia operativa.
-                </p>
-                <h3>GoFarma</h3>
-                <p>
-                  Como co-fundador y Director de Operaciones, diseñé e implementé un modelo operativo innovador que logró una precisión de inventario del 99.8% y redujo significativamente los tiempos de entrega.
-                </p>
-                <h3>Farmalisto</h3>
-                <p>
-                  En mi rol como Director de Ventas en Marketplaces, lideré la expansión digital de la compañía, impulsando un incremento del 144% en ventas y reduciendo considerablemente reclamos y cancelaciones.
-                </p>
-              </div>
+          <div className="content-container">
+            <div className="image-container">
+              <LazyLoadImage src={professional} alt="Resultados profesionales" width={500} height={500} effect="blur" placeholderSrc={professional} className="optimized-image" />
             </div>
-          </>
+            <div className="text-content">
+              <h3>+10 años transformando operaciones</h3>
+              <p>Experiencia entre logística, e-commerce, marketplaces, producto digital y automatización de procesos.</p>
+              <h3>99.8% de precisión de inventario</h3>
+              <p>Modelo operativo en GoFarma con foco en control, velocidad y confiabilidad para operación tipo dark store.</p>
+              <h3>144% de crecimiento en marketplaces</h3>
+              <p>Expansión digital en Farmalisto con mejora comercial, visibilidad y reducción de fricción operativa.</p>
+            </div>
+          </div>
         ),
       },
       {
-        title: 'Visión Tecnológica',
+        title: 'Casos mínimos',
         image: tech_vision,
-        alt: 'Visión Tecnológica',
-        subtitle: 'Creo en el poder de la tecnología para transformar negocios y construir un futuro más eficiente.',
+        alt: 'Casos de estudio',
+        subtitle: 'Problema → solución → resultado. Sin buzzwords.',
         content: (
-          <>
-            <div className="content-container">
-              <div className="image-container">
-                <LazyLoadImage
-                  src={tech_vision}
-                  alt="Visión Tecnológica"
-                  width={500}
-                  height={500}
-                  effect="blur"
-                  placeholderSrc={tech_vision}
-                  className="optimized-image"
-                />
-              </div>
-              <div className="text-content">
-                <p>
-                  Hace algunos años, durante la implementación de un sistema de automatización en una cadena logística, tuve una revelación: no solo optimizábamos procesos, sino que también transformábamos la vida de las personas, facilitándoles las tareas y mejorando su bienestar.
-                </p>
-                <p>
-                  Estoy convencido del poder transformador de la tecnología en los negocios. Mi enfoque se centra en aprovechar soluciones innovadoras, como la inteligencia artificial, la automatización y el análisis de datos, para impulsar la eficiencia operativa y el crecimiento empresarial.
-                </p>
-                <p>
-                  Si compartes mi visión de un futuro más eficiente y tecnológicamente avanzado, me encantaría colaborar contigo para convertir tu negocio en una verdadera historia de éxito.
-                </p>
-              </div>
+          <div className="content-container">
+            <div className="image-container">
+              <LazyLoadImage src={tech_vision} alt="Casos de estudio" width={500} height={500} effect="blur" placeholderSrc={tech_vision} className="optimized-image" />
             </div>
-          </>
+            <div className="text-content">
+              <h3>GoFarma</h3>
+              <p><strong>Problema:</strong> operación con inventario sensible y presión de entregas. <strong>Solución:</strong> modelo operativo estandarizado para dark store. <strong>Resultado:</strong> 99.8% de precisión de inventario.</p>
+              <h3>Farmalisto</h3>
+              <p><strong>Problema:</strong> canal marketplace con fricción comercial y operativa. <strong>Solución:</strong> gestión de presencia online y optimización de catálogo/canales. <strong>Resultado:</strong> 144% de incremento en ventas.</p>
+              <h3>CHUBB</h3>
+              <p><strong>Problema:</strong> procesos de renovación con alta complejidad operativa. <strong>Solución:</strong> liderazgo de producto para automatización, UX y priorización. <strong>Resultado:</strong> mejoras digitales en cotización, emisión y experiencia.</p>
+            </div>
+          </div>
         ),
       },
     ],
     en: [
       {
-        title: 'Personal Story',
+        title: 'Outcomes',
         image: personal_story,
-        alt: 'Personal Story',
-        subtitle: 'Since I can remember, I’ve always had a great curiosity about how things work.',
+        alt: 'Elier Loya',
+        subtitle: 'I went from coordinating operations at PepsiCo to co-founding a startup with 99.8% inventory accuracy.',
         content: (
-          <>
-            <div className="content-container">
-              <div className="image-container">
-                <LazyLoadImage
-                  src={personal_story}
-                  alt="Personal Story"
-                  width={500}
-                  height={500}
-                  effect="blur"
-                  placeholderSrc={personal_story}
-                  className="optimized-image"
-                />
-              </div>
-              <div className="text-content">
-                <p>
-                  This curiosity led me to disassemble toys, study engineering, and ultimately, transform companies through technology.
-                </p>
-                <p>
-                  I’m Elier Loya, an Industrial and Systems Engineer with over 10 years of experience in directing and optimizing operations. My passion for technology and innovation has led me to specialize in digital transformation and logistics management.
-                </p>
-                <p>
-                  Throughout my career, I have led key transformations at companies such as GoFarma, Farmalisto, and PepsiCo. Currently, at CHUBB, I leverage my expertise to drive digital transformation in the renewals area, enhancing the automation and customization of critical processes.
-                </p>
-              </div>
+          <div className="content-container">
+            <div className="image-container">
+              <LazyLoadImage src={personal_story} alt="Elier Loya" width={500} height={500} effect="blur" placeholderSrc={personal_story} className="optimized-image" />
             </div>
-          </>
+            <div className="text-content">
+              <p>I combine operational judgment, product thinking and technical execution to move projects out of strategic or technical complexity.</p>
+              <p>If you have a validatable idea, a stuck process or an automation that could move revenue, costs or speed, I translate it into scope, prototype and metrics.</p>
+              <p><strong>If your project is stuck, we unblock it with focus.</strong></p>
+            </div>
+          </div>
         ),
       },
       {
-        title: 'Highlighted Experience',
+        title: 'Hard numbers',
         image: professional,
-        alt: 'Highlighted Experience',
-        subtitle: 'My achievements reflect my commitment to operational excellence and my passion for transforming businesses.',
+        alt: 'Professional outcomes',
+        subtitle: '+10 years transforming operations, digital products and commercial channels.',
         content: (
-          <>
-            <div className="content-container">
-              <div className="image-container">
-                <LazyLoadImage
-                  src={professional}
-                  alt="Highlighted Experience"
-                  width={500}
-                  height={500}
-                  effect="blur"
-                  placeholderSrc={professional}
-                  className="optimized-image"
-                />
-              </div>
-              <div className="text-content">
-                <h3>CHUBB</h3>
-                <p>
-                  Currently, as a Digital Product Owner at CHUBB, I lead the digital transformation of the policy renewals area by driving automation and customization of critical processes to improve customer experience and operational efficiency.
-                </p>
-                <h3>GoFarma</h3>
-                <p>
-                  As co-founder and Chief Operating Officer, I designed and implemented an innovative operational model that achieved 99.8% inventory accuracy and significantly reduced delivery times.
-                </p>
-                <h3>Farmalisto</h3>
-                <p>
-                  In my role as Director of Marketplaces Sales, I led the company's online presence expansion, achieving a 144% increase in sales and a significant reduction in claims and cancellations.
-                </p>
-              </div>
+          <div className="content-container">
+            <div className="image-container">
+              <LazyLoadImage src={professional} alt="Professional outcomes" width={500} height={500} effect="blur" placeholderSrc={professional} className="optimized-image" />
             </div>
-          </>
+            <div className="text-content">
+              <h3>+10 years transforming operations</h3>
+              <p>Experience across logistics, e-commerce, marketplaces, digital product and process automation.</p>
+              <h3>99.8% inventory accuracy</h3>
+              <p>Operational model at GoFarma focused on control, speed and reliability for a dark-store operation.</p>
+              <h3>144% marketplace growth</h3>
+              <p>Digital expansion at Farmalisto through online presence, catalog and channel optimization.</p>
+            </div>
+          </div>
         ),
       },
       {
-        title: 'Technological Vision',
+        title: 'Mini cases',
         image: tech_vision,
-        alt: 'Technological Vision',
-        subtitle: 'I believe in the power of technology to transform businesses and build a more efficient future.',
+        alt: 'Case studies',
+        subtitle: 'Problem → solution → result. No buzzwords.',
         content: (
-          <>
-            <div className="content-container">
-              <div className="image-container">
-                <LazyLoadImage
-                  src={tech_vision}
-                  alt="Technological Vision"
-                  width={500}
-                  height={500}
-                  effect="blur"
-                  placeholderSrc={tech_vision}
-                  className="optimized-image"
-                />
-              </div>
-              <div className="text-content">
-                <p>
-                  A few years ago, while implementing an automation system in a logistics chain, I had an epiphany: I realized that we were not only optimizing processes, but also changing the lives of the people working there, making their tasks easier and their jobs more fulfilling.
-                </p>
-                <p>
-                  I firmly believe in the transformative power of technology in business. My focus is on leveraging innovative solutions such as AI, automation, and data analysis to drive operational efficiency and business growth.
-                </p>
-                <p>
-                  If you share my vision of a more efficient and technologically advanced future, I’d love to collaborate with you to turn your business into a success story.
-                </p>
-              </div>
+          <div className="content-container">
+            <div className="image-container">
+              <LazyLoadImage src={tech_vision} alt="Case studies" width={500} height={500} effect="blur" placeholderSrc={tech_vision} className="optimized-image" />
             </div>
-          </>
+            <div className="text-content">
+              <h3>GoFarma</h3>
+              <p><strong>Problem:</strong> inventory-sensitive operation under delivery pressure. <strong>Solution:</strong> standardized dark-store operating model. <strong>Result:</strong> 99.8% inventory accuracy.</p>
+              <h3>Farmalisto</h3>
+              <p><strong>Problem:</strong> marketplace channel with commercial and operational friction. <strong>Solution:</strong> online presence and catalog/channel optimization. <strong>Result:</strong> 144% sales growth.</p>
+              <h3>CHUBB</h3>
+              <p><strong>Problem:</strong> renewal processes with high operational complexity. <strong>Solution:</strong> product leadership for automation, UX and prioritization. <strong>Result:</strong> digital improvements in quote, issuance and experience.</p>
+            </div>
+          </div>
         ),
       },
     ],
@@ -271,17 +181,11 @@ function SobreMi({ style }) {
   });
 
   const scrollToServicios = () => {
-    const serviciosSection = document.getElementById('servicios');
-    if (serviciosSection) {
-      serviciosSection.scrollIntoView({ behavior: 'smooth' });
-    }
+    document.getElementById('disponibilidad')?.scrollIntoView({ behavior: 'smooth' });
   };
 
   const scrollToContacto = () => {
-    const contactoSection = document.getElementById('contacto');
-    if (contactoSection) {
-      contactoSection.scrollIntoView({ behavior: 'smooth' });
-    }
+    document.getElementById('diagnostico')?.scrollIntoView({ behavior: 'smooth' });
   };
 
   const handleManualChange = (index) => {
@@ -297,46 +201,28 @@ function SobreMi({ style }) {
   return (
     <section id="sobre-mi" className="sobre-mi" style={style} {...swipeHandlers}>
       <div className="contenido-sobre-mi">
-        <h2>{language === 'es' ? 'SOBRE MI' : 'ABOUT ME'}</h2>
+        <h2>{language === 'es' ? 'SOBRE MÍ' : 'ABOUT ME'}</h2>
 
         <div className="tabs">
-          <button
-            className="nav-arrow left"
-            onClick={() => handleManualChange((currentSection - 1 + sections[language].length) % sections[language].length)}
-          >
-            &lt;
-          </button>
+          <button className="nav-arrow left" onClick={() => handleManualChange((currentSection - 1 + sections[language].length) % sections[language].length)}>&lt;</button>
           {sections[language].map((section, index) => (
-            <button
-              key={index}
-              className={`tab-button ${currentSection === index ? 'active' : ''}`}
-              onClick={() => handleManualChange(index)}
-            >
+            <button key={index} className={`tab-button ${currentSection === index ? 'active' : ''}`} onClick={() => handleManualChange(index)}>
               {section.title}
             </button>
           ))}
-          <button
-            className="nav-arrow right"
-            onClick={() => handleManualChange((currentSection + 1) % sections[language].length)}
-          >
-            &gt;
-          </button>
+          <button className="nav-arrow right" onClick={() => handleManualChange((currentSection + 1) % sections[language].length)}>&gt;</button>
         </div>
         <div className="section-content">
           <div className="sub-title-container shinyy">{sections[language][currentSection].subtitle}</div>
           {sections[language][currentSection].content}
         </div>
         <div className="cta-seccion-sobre-mi">
-          <button onClick={scrollToServicios} className="cta-button-2">{language === 'es' ? 'Mis Servicios' : 'My Services'}</button>
-          <button onClick={scrollToContacto} className="cta-button-2">{language === 'es' ? 'Contáctame' : 'Contact Me'}</button>
+          <button onClick={scrollToServicios} className="cta-button-2">{language === 'es' ? 'Ver método' : 'See method'}</button>
+          <button onClick={scrollToContacto} className="cta-button-2">{language === 'es' ? 'Recibe diagnóstico' : 'Get diagnosis'}</button>
         </div>
         <div className="horizontal-scroll-indicator">
           {sections[language].map((_, index) => (
-            <div
-              key={index}
-              className={`indicator ${currentSection === index ? 'active-indicator' : ''}`}
-              onClick={() => handleManualChange(index)}
-            />
+            <div key={index} className={`indicator ${currentSection === index ? 'active' : ''}`}></div>
           ))}
         </div>
       </div>

--- a/my-app/src/components/utils/translations.js
+++ b/my-app/src/components/utils/translations.js
@@ -58,19 +58,22 @@ I'm here to help you find what you need!
         languageToggle: "EN",
 
         // Página de agradecimiento
-        thanksTitle: "Session Confirmed",
-        thanksDescription: "Thank you for scheduling your Express Diagnosis. We sent you the confirmation by email. You can close this tab or return to elelier.com.",
+        thanksTitle: "Diagnosis received",
+        thanksDescription: "Thanks for sending your express diagnosis. The next useful step is a 20-minute call to review scope, fit and a practical first move.",
         thanksButton: "Back to elelier.com",
+        thanksCalendarButton: "Schedule 20-minute call",
 
         // Lead Qualifier
-        leadQualifierTitle: "Express Diagnosis",
-        leadQualifierSubtitle: "Tell me your challenge and I'll tell you the next step.",
+        leadQualifierTitle: "Express diagnosis",
+        leadQualifierSubtitle: "Answer 5 focused questions. I use them to separate vague ideas from a project we can actually move in weeks.",
         leadName: "Name",
+        leadNameCompany: "Your name / company",
         leadEmail: "Email",
         leadCompanyType: "Company Type",
-        leadProblem: "Challenge Type",
-        leadBudget: "Budget",
-        leadUrgency: "Urgency",
+        leadProblem: "What is your main challenge?",
+        leadBudget: "Estimated monthly budget",
+        leadUrgency: "What is your urgency?",
+        leadExpectedOutcome: "What do you expect to achieve in 30 days?",
         leadSelectOption: "Select an option",
         leadFreelancer: "Freelancer",
         leadStartup: "Startup",
@@ -80,8 +83,22 @@ I'm here to help you find what you need!
         leadProducto: "Product",
         leadIA: "AI",
         leadWeb: "Web",
-        leadSubmitButton: "Send diagnosis",
+        leadValidateIdea: "Validate an idea",
+        leadOptimizeProcess: "Optimize an existing process",
+        leadAutomateAI: "Automate with AI",
+        leadOther: "Other",
+        leadNext30Days: "Next 30 days",
+        leadThisQuarter: "This quarter",
+        leadExploring: "Exploring",
+        leadBudgetUnder1k: "Less than $1k",
+        leadBudgetUnknown: "I don't know yet",
+        leadOutcomePrototype: "Working prototype",
+        leadOutcomeAutomation: "Small automation running",
+        leadOutcomeMetrics: "Clear metrics / dashboard",
+        leadOutcomeClarity: "Scope and roadmap clarity",
+        leadSubmitButton: "Get express diagnosis",
         leadAnalyzing: "Analyzing...",
+        leadRedirecting: "Preparing next step...",
         leadCalendarOpened: "Calendar opened ✅",
         leadError: "An error occurred. Try again later.",
         leadTooFast: "You're sending too fast. Try in a few minutes.",
@@ -95,7 +112,7 @@ I'm here to help you find what you need!
         leadLowTitle: "Recommended resource",
         leadLowDescription: "We leave you a resource to move forward with clarity.",
         leadLowAction: "View resource",
-        leadSuccessGeneric: "Thank you. We will show you the next step.",
+        leadSuccessGeneric: "Diagnosis received. I’m preparing the next step.",
         leadFollowupMetric: "What is your main metric to move?",
         leadFollowupData: "Do you have data available?",
         leadFollowupDecision: "Who decides?",
@@ -167,19 +184,22 @@ Explora <a href="#hero-banner" onclick="scrollToSection('hero-banner'); return f
         languageToggle: "ES",
 
         // Página de agradecimiento
-        thanksTitle: "Sesión confirmada",
-        thanksDescription: "Gracias por agendar tu Diagnóstico Express. Te enviamos la confirmación por email. Puedes cerrar esta pestaña o volver a elelier.com.",
+        thanksTitle: "Diagnóstico recibido",
+        thanksDescription: "Gracias por enviar tu diagnóstico exprés. El siguiente paso útil es una llamada de 20 minutos para revisar alcance, encaje y primera acción práctica.",
         thanksButton: "Volver a elelier.com",
+        thanksCalendarButton: "Agendar llamada de 20 min",
 
         // Lead Qualifier
-        leadQualifierTitle: "Diagnóstico Express",
-        leadQualifierSubtitle: "Cuéntame tu reto y te digo el siguiente paso.",
+        leadQualifierTitle: "Diagnóstico exprés",
+        leadQualifierSubtitle: "Responde 5 preguntas concretas. Las uso para separar ideas vagas de proyectos que sí podemos mover en semanas.",
         leadName: "Nombre",
+        leadNameCompany: "Tu nombre / empresa",
         leadEmail: "Email",
         leadCompanyType: "Tipo de empresa",
-        leadProblem: "Tipo de reto",
-        leadBudget: "Presupuesto",
-        leadUrgency: "Urgencia",
+        leadProblem: "¿Cuál es tu reto principal?",
+        leadBudget: "Presupuesto mensual estimado",
+        leadUrgency: "¿Cuál es tu urgencia?",
+        leadExpectedOutcome: "¿Qué esperas lograr en 30 días?",
         leadSelectOption: "Selecciona una opción",
         leadFreelancer: "Freelancer",
         leadStartup: "Startup",
@@ -189,8 +209,22 @@ Explora <a href="#hero-banner" onclick="scrollToSection('hero-banner'); return f
         leadProducto: "Producto",
         leadIA: "IA",
         leadWeb: "Web",
-        leadSubmitButton: "Enviar diagnóstico",
+        leadValidateIdea: "Validar una idea",
+        leadOptimizeProcess: "Optimizar un proceso existente",
+        leadAutomateAI: "Automatizar con IA",
+        leadOther: "Otro",
+        leadNext30Days: "Próximos 30 días",
+        leadThisQuarter: "Este trimestre",
+        leadExploring: "Explorando",
+        leadBudgetUnder1k: "Menos de $1k",
+        leadBudgetUnknown: "No lo sé",
+        leadOutcomePrototype: "Prototipo funcional",
+        leadOutcomeAutomation: "Automatización pequeña corriendo",
+        leadOutcomeMetrics: "Métricas claras / dashboard",
+        leadOutcomeClarity: "Claridad de alcance y roadmap",
+        leadSubmitButton: "Recibe diagnóstico exprés",
         leadAnalyzing: "Analizando...",
+        leadRedirecting: "Preparando siguiente paso...",
         leadCalendarOpened: "Calendario abierto ✅",
         leadError: "Ocurrió un error. Intenta más tarde.",
         leadTooFast: "Estás enviando muy rápido. Intenta en unos minutos.",
@@ -204,7 +238,7 @@ Explora <a href="#hero-banner" onclick="scrollToSection('hero-banner'); return f
         leadLowTitle: "Recurso recomendado",
         leadLowDescription: "Te dejamos un recurso para avanzar con claridad.",
         leadLowAction: "Ver recurso",
-        leadSuccessGeneric: "Gracias. Te mostraremos el siguiente paso.",
+        leadSuccessGeneric: "Diagnóstico recibido. Estoy preparando el siguiente paso.",
         leadFollowupMetric: "¿Cuál es tu principal métrica a mover?",
         leadFollowupData: "¿Tienes datos disponibles?",
         leadFollowupDecision: "¿Quién decide?",
@@ -233,20 +267,10 @@ export function changeLanguage(newLanguage) {
     localStorage.setItem('language', newLanguage);
     document.documentElement.lang = newLanguage;
     updateDynamicContent(newLanguage);
-    // You might want to dispatch a custom event here to notify other parts of your app
     const event = new CustomEvent('languageChanged', { detail: { language: newLanguage } });
     document.dispatchEvent(event);
 }
 
-export function updateDynamicContent(language) {
-    document.querySelectorAll('[data-en], [data-es]').forEach((element) => {
-        element.textContent = element.getAttribute(`data-${language}`) || element.getAttribute('data-en');
-    });
-
-    document.querySelectorAll('input[placeholder]').forEach((input) => {
-        const key = input.getAttribute('data-placeholder-key');
-        if (key && translations[language][key]) {
-            input.placeholder = translations[language][key];
-        }
-    });
-};
+function updateDynamicContent() {
+    // Kept as a safe no-op for legacy inline chat links.
+}

--- a/my-app/src/pages/GraciasAgenda.jsx
+++ b/my-app/src/pages/GraciasAgenda.jsx
@@ -1,16 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import '../styles/GraciasAgenda.css';
 
+const DEFAULT_CAL_URL = 'https://cal.com/elelier/diagnostico';
+
 const GraciasAgenda = () => {
   const { translate } = useLanguage();
+  const [calendarUrl, setCalendarUrl] = useState(DEFAULT_CAL_URL);
+
+  useEffect(() => {
+    const storedUrl = sessionStorage.getItem('elelierLastDiagnosisCalUrl');
+    if (storedUrl) {
+      setCalendarUrl(storedUrl);
+    }
+  }, []);
 
   return (
     <main className="gracias-agenda">
       <section className="gracias-agenda__card">
         <h1>{translate('thanksTitle')}</h1>
         <p>{translate('thanksDescription')}</p>
-        <a className="gracias-agenda__button" href="/">{translate('thanksButton')}</a>
+        <a className="gracias-agenda__button" href={calendarUrl} target="_blank" rel="noreferrer">
+          {translate('thanksCalendarButton')}
+        </a>
+        <a className="gracias-agenda__button gracias-agenda__button--secondary" href="/">
+          {translate('thanksButton')}
+        </a>
       </section>
     </main>
   );

--- a/my-app/src/styles/GraciasAgenda.css
+++ b/my-app/src/styles/GraciasAgenda.css
@@ -4,7 +4,6 @@
   align-items: center;
   justify-content: center;
   padding: 120px 16px 80px;
-  /* Gradiente de puente: conecta hero → contenido */
   background: linear-gradient(
     to bottom,
     var(--color-bg-3) 0%,
@@ -44,9 +43,9 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
+  margin: 6px 8px 0 0;
   padding: 12px 18px;
   border-radius: 20px;
-  /* Gradiente coherente con hero-button */
   background: linear-gradient(135deg, #a80c9b, #7bcff8, #00cc99);
   background-size: 300% 300%;
   animation: gradientBG 10s ease infinite;
@@ -55,6 +54,13 @@
   font-weight: 600;
   border: none;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.gracias-agenda__button--secondary {
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  animation: none;
 }
 
 .gracias-agenda__button:hover {

--- a/my-app/src/styles/components/LeadQualifier.css
+++ b/my-app/src/styles/components/LeadQualifier.css
@@ -39,10 +39,41 @@
   gap: 18px;
 }
 
-.lead-qualifier__field {
+.lead-qualifier__field,
+.lead-qualifier__fieldset {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.lead-qualifier__fieldset {
+  margin: 0;
+  padding: 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  background-color: rgba(var(--hero-title-color-rgb), 0.06);
+}
+
+.lead-qualifier__fieldset legend {
+  padding: 0 8px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.lead-qualifier__fieldset label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  line-height: 1.35;
+  color: var(--color-text);
+  cursor: pointer;
+}
+
+.lead-qualifier__fieldset input[type='radio'] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--color-accent);
 }
 
 .lead-qualifier__field label {


### PR DESCRIPTION
## Summary
- Rewrites hero copy around a stronger business outcome and promotes the diagnosis CTA as primary.
- Simplifies the diagnosis lead magnet into focused qualification questions while preserving the existing `https://leads.elelier.com/api/lead` backend contract.
- Adds `/gracias-diagnostico` as the post-submit next-step page with a 20-minute Cal.com action.
- Reframes Sobre Mí around outcomes, hard numbers and mini case studies.
- Replaces the negative availability framing with a 3-step working method.

## Validation
- Static repository edits via GitHub connector.
- Compared branch against `main`: 9 files changed, branch is ahead by 9 commits and behind by 0.

## Notes / Risks
- I could not run `npm run build` from this environment because the repo is only available through the GitHub connector here, not as a local checkout with network access.
- The form still posts to the current production lead endpoint and may need a live smoke after deploy.
- Testimonials, new professional video/photo assets and full internal case-study pages remain pending because they require external assets or verified testimonial content.