### PR TITLE
[codex] Align hero message and CTA

### DIFF
--- a/my-app/src/components/HeroBanner.js
+++ b/my-app/src/components/HeroBanner.js
@@ -4,6 +4,8 @@ import { ThemeContext } from '../contexts/ThemeContext';
 import heroPortrait from '../assets/images/profile-picture-elier2.png';
 import '../styles/components/HeroBanner.css';
 
+const CALENDLY_URL = 'https://calendly.com/loya-elier/primer-contacto-15-min';
+
 const DynamicHeroBanner = ({ style }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -14,8 +16,8 @@ const DynamicHeroBanner = ({ style }) => {
   const heroContent = useMemo(() => ({
     es: [
       {
-        title: 'Llevo tu idea de negocio a un producto digital funcional en semanas, no meses',
-        subtitle: 'Ex-COO de GoFarma y Digital Product Owner en CHUBB. Solo tomo proyectos con foco.',
+        title: 'Transformo procesos complicados en soluciones que realmente funcionan.',
+        subtitle: 'Ex-COO de GoFarma y Digital Product Owner en CHUBB.',
         description: 'Estrategia, prototipo y métricas reales para validar, automatizar o destrabar un reto operativo sin humo.',
         icon: '🧪',
         cta: 'Diagnóstico exprés',
@@ -25,7 +27,7 @@ const DynamicHeroBanner = ({ style }) => {
     en: [
       {
         title: 'I turn your business idea into a working digital product in weeks, not months',
-        subtitle: 'Ex-COO at GoFarma and Digital Product Owner at CHUBB. I only take focused projects.',
+        subtitle: 'Ex-COO at GoFarma and Digital Product Owner at CHUBB.',
         description: 'Strategy, prototype and real metrics to validate, automate or unblock an operational challenge without fluff.',
         icon: '🧪',
         cta: 'Express diagnosis',
@@ -128,9 +130,9 @@ const DynamicHeroBanner = ({ style }) => {
           <h3 className="hero-subtitle">{currentContent?.subtitle}</h3>
           <p className="hero-description">{currentContent?.description}</p>
           <div className="hero-actions" aria-label="Acciones principales">
-            <button className="hero-button" onClick={() => scrollToSection('diagnostico')}>
+            <a className="hero-button" href={CALENDLY_URL} target="_blank" rel="noopener noreferrer">
               {currentContent?.cta} →
-            </button>
+            </a>
             <button className="hero-button-secondary" onClick={() => scrollToSection('casos-reales')}>
               {currentContent?.secondaryCta}
             </button>

--- a/my-app/src/components/HeroBanner.js
+++ b/my-app/src/components/HeroBanner.js
@@ -20,7 +20,7 @@ const DynamicHeroBanner = ({ style }) => {
         subtitle: 'Ex-COO de GoFarma y Digital Product Owner en CHUBB.',
         description: 'Estrategia, prototipo y métricas reales para validar, automatizar o destrabar un reto operativo sin humo.',
         icon: '🧪',
-        cta: 'Diagnóstico exprés',
+        cta: 'Agenda una llamada',
         secondaryCta: 'Ver casos reales'
       }
     ],
@@ -30,7 +30,7 @@ const DynamicHeroBanner = ({ style }) => {
         subtitle: 'Ex-COO at GoFarma and Digital Product Owner at CHUBB.',
         description: 'Strategy, prototype and real metrics to validate, automate or unblock an operational challenge without fluff.',
         icon: '🧪',
-        cta: 'Express diagnosis',
+        cta: 'Schedule a call',
         secondaryCta: 'See real cases'
       }
     ]

--- a/my-app/src/components/HeroBanner.test.js
+++ b/my-app/src/components/HeroBanner.test.js
@@ -52,7 +52,7 @@ describe('HeroBanner', () => {
     expect(container.textContent).not.toContain('producto digital funcional en semanas, no meses');
 
     const primaryCta = container.querySelector('.hero-button');
-    expect(primaryCta.textContent).toContain('Diagnóstico exprés');
+    expect(primaryCta.textContent).toContain('Agenda una llamada');
     expect(primaryCta.tagName).toBe('A');
     expect(primaryCta.getAttribute('href')).toBe(calendlyUrl);
 
@@ -62,10 +62,11 @@ describe('HeroBanner', () => {
     cleanup();
   });
 
-  it('keeps the existing English headline until a stakeholder translation is approved', () => {
+  it('keeps the existing English headline and shows the updated English CTA', () => {
     const { container, cleanup } = renderHero('en');
 
     expect(container.textContent).toContain('I turn your business idea into a working digital product in weeks, not months');
+    expect(container.querySelector('.hero-button').textContent).toContain('Schedule a call');
 
     cleanup();
   });

--- a/my-app/src/components/HeroBanner.test.js
+++ b/my-app/src/components/HeroBanner.test.js
@@ -1,0 +1,72 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import HeroBanner from './HeroBanner';
+import { LanguageContext } from '../contexts/LanguageContext';
+import { ThemeContext } from '../contexts/ThemeContext';
+
+const calendlyUrl = 'https://calendly.com/loya-elier/primer-contacto-15-min';
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderHero = (language = 'es') => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <LanguageContext.Provider value={{ language }}>
+        <ThemeContext.Provider value={{ currentTheme: 'light' }}>
+          <HeroBanner />
+        </ThemeContext.Provider>
+      </LanguageContext.Provider>
+    );
+  });
+
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    }
+  };
+};
+
+describe('HeroBanner', () => {
+  beforeEach(() => {
+    jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      clearRect: jest.fn()
+    });
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('shows the approved Spanish hero message and Calendly CTA', () => {
+    const { container, cleanup } = renderHero('es');
+
+    expect(container.textContent).toContain('Transformo procesos complicados en soluciones que realmente funcionan.');
+    expect(container.textContent).not.toContain('Solo tomo proyectos con foco');
+    expect(container.textContent).not.toContain('producto digital funcional en semanas, no meses');
+
+    const primaryCta = container.querySelector('.hero-button');
+    expect(primaryCta.textContent).toContain('Diagnóstico exprés');
+    expect(primaryCta.tagName).toBe('A');
+    expect(primaryCta.getAttribute('href')).toBe(calendlyUrl);
+
+    const secondaryCta = container.querySelector('.hero-button-secondary');
+    expect(secondaryCta.textContent).toContain('Ver casos reales');
+
+    cleanup();
+  });
+
+  it('keeps the existing English headline until a stakeholder translation is approved', () => {
+    const { container, cleanup } = renderHero('en');
+
+    expect(container.textContent).toContain('I turn your business idea into a working digital product in weeks, not months');
+
+    cleanup();
+  });
+});

--- a/my-app/src/setupTests.js
+++ b/my-app/src/setupTests.js
@@ -1,5 +1,8 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+// jest-dom is optional in this project checkout; keep tests runnable when it is not installed.
+try {
+  require('@testing-library/jest-dom');
+} catch (error) {
+  if (error.code !== 'MODULE_NOT_FOUND') {
+    throw error;
+  }
+}

--- a/my-app/src/styles/components/HeroBanner.css
+++ b/my-app/src/styles/components/HeroBanner.css
@@ -111,11 +111,15 @@ html { scroll-behavior: smooth; }
 }
 
 .hero-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: linear-gradient(135deg, #a80c9b, #7bcff8, #00cc99);
   background-size: 300% 300%;
   animation: gradientBG 10s ease infinite;
   color: #ffffff;
   border: none;
+  text-decoration: none;
 }
 
 .hero-button-secondary {


### PR DESCRIPTION
## Summary
- Updates the Spanish hero headline to the approved message: "Transformo procesos complicados en soluciones que realmente funcionan."
- Removes the deprecated focus/weeks phrasing from the hero copy.
- Changes the primary hero CTA into a semantic link styled with the existing CTA class and pointing to Calendly.
- Updates the primary CTA visible text to "Agenda una llamada" in Spanish and "Schedule a call" in English.
- Keeps the secondary CTA "Ver casos reales" scrolling to `#casos-reales`.

## Scope control
- Did not change Diagnóstico Exprés.
- Did not change Servicios, Carrera, Casos de estudio, images, visual structure, or other sections.
- Did not add dependencies.
- Did not change the lower "Ver diagnóstico" indicator.

## Validation
- `npm test -- --runInBand src/components/HeroBanner.test.js` passed.
- `npm run build` passed.
- `git diff --check` passed.
- Manual desktop hero check passed at `http://127.0.0.1:3000`.
- Manual mobile hero check passed at 390x844 viewport.
- Calendly CTA click opened `https://calendly.com/loya-elier/primer-contacto-15-min?month=2026-07`.
- Removed phrases were not found in `HeroBanner.js`.

## Risks / pending
- The lower hero indicator still says "Ver diagnóstico" by explicit scope instruction. This may coexist awkwardly with the Calendly primary CTA and should be resolved in a follow-up product decision.
- No approved English translation was provided for the new Spanish tagline, so the previous English headline remains in place. English subtitle removes the direct equivalent of "Solo tomo proyectos con foco."
- `setupTests.js` exposes preexisting test setup debt: it originally imported `@testing-library/jest-dom` without that package being backed by a direct project dependency. The fallback in this PR keeps the new hero test from failing due to missing test configuration rather than hero behavior.

Closes #27