### PR TITLE
Fix conversion CTAs and navigation targets

### DIFF
--- a/my-app/src/components/CasosEstudio.js
+++ b/my-app/src/components/CasosEstudio.js
@@ -101,7 +101,6 @@ function CasosEstudio({ style }) {
             <p className="caso-card__category">{caseStudy.category}</p>
             <div className="caso-card__title-row">
               <h3>{caseStudy.title}</h3>
-              <span aria-hidden="true">→</span>
             </div>
             <div className="caso-card__blocks">
               <p><strong>{t.labels.challenge}</strong>{caseStudy.challenge}</p>

--- a/my-app/src/components/CasosEstudio.test.js
+++ b/my-app/src/components/CasosEstudio.test.js
@@ -83,6 +83,14 @@ describe('CasosEstudio', () => {
     cleanup();
   });
 
+  it('does not render decorative arrows next to case titles', () => {
+    const { container, cleanup } = renderCasosEstudio('es');
+
+    expect(container.querySelector('.caso-card__title-row').textContent).not.toContain('→');
+
+    cleanup();
+  });
+
   it('renders descriptive static previews for both projects', () => {
     const { container, cleanup } = renderCasosEstudio('es');
 

--- a/my-app/src/components/Contacto.js
+++ b/my-app/src/components/Contacto.js
@@ -20,8 +20,7 @@ const texts = {
     whatsapp: 'Envíame un mensaje',
     location: 'Monterrey, México',
     professionalLinks: 'Enlaces Profesionales',
-    agenda: 'Agenda 15 minutos',
-    downloadCV: 'Descargar CV',
+    downloadCV: 'Ver CV (PDF)',
     linkedin: 'LinkedIn',
     github: 'GitHub',
     namePlaceholder: 'Nombre',
@@ -39,8 +38,7 @@ const texts = {
     whatsapp: 'Message Me',
     location: 'Monterrey, Mexico',
     professionalLinks: 'Professional Links',
-    agenda: 'Schedule 15 minutes',
-    downloadCV: 'Download Resume',
+    downloadCV: 'View resume (PDF)',
     linkedin: 'LinkedIn',
     github: 'GitHub',
     namePlaceholder: 'Name',
@@ -101,7 +99,7 @@ function Contacto({ style }) {
     <motion.section
       id="contacto"
       className="contacto"
-      style={style}
+      style={{ scrollMarginTop: '96px', ...style }}
       initial={{ opacity: 0, y: 50 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
@@ -174,14 +172,9 @@ function Contacto({ style }) {
                   {t.github}
                 </a>
               </div>
-              <h3>Agenda y Documentos</h3>
               <div className="agenda-documentos-links">
-                <a href="https://calendly.com/loya-elier/primer-contacto-15-min" target="_blank" rel="noopener noreferrer" className="agenda-documentos-link">
-                  <i className="fas fa-calendar-check"></i>
-                  {t.agenda}
-                </a>
-                <a href={CV} download className="agenda-documentos-link">
-                  <i className="fas fa-file-download"></i>
+                <a href={CV} target="_blank" rel="noopener noreferrer" className="agenda-documentos-link">
+                  <i className="fas fa-file-pdf"></i>
                   {t.downloadCV}
                 </a>
               </div>

--- a/my-app/src/components/Contacto.test.js
+++ b/my-app/src/components/Contacto.test.js
@@ -1,0 +1,63 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import Contacto from './Contacto';
+import { LanguageContext } from '../contexts/LanguageContext';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderContacto = (language = 'es') => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <MemoryRouter>
+        <LanguageContext.Provider value={{ language }}>
+          <Contacto />
+        </LanguageContext.Provider>
+      </MemoryRouter>
+    );
+  });
+
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    }
+  };
+};
+
+describe('Contacto', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('removes public Calendly references and exposes the resume as a safe PDF link in Spanish', () => {
+    const { container, cleanup } = renderContacto('es');
+
+    expect(container.textContent).not.toContain('Agenda 15 minutos');
+    expect(container.textContent).not.toContain('Agenda y Documentos');
+    expect(container.innerHTML).not.toContain('calendly.com');
+
+    const resumeLink = Array.from(container.querySelectorAll('a')).find((link) => link.textContent.includes('Ver CV (PDF)'));
+
+    expect(resumeLink).toBeTruthy();
+    expect(resumeLink.getAttribute('target')).toBe('_blank');
+    expect(resumeLink.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(resumeLink.hasAttribute('download')).toBe(false);
+
+    cleanup();
+  });
+
+  it('renders the approved English resume copy', () => {
+    const { container, cleanup } = renderContacto('en');
+
+    expect(container.textContent).not.toContain('Schedule 15 minutes');
+    expect(container.textContent).toContain('View resume (PDF)');
+
+    cleanup();
+  });
+});

--- a/my-app/src/components/Footer.js
+++ b/my-app/src/components/Footer.js
@@ -12,7 +12,7 @@ function Footer() {
       sobreMi: 'Sobre Mí',
       habilidades: 'Habilidades',
       portafolio: 'Portafolio',
-      servicios: 'Servicios',
+      servicios: 'Cómo trabajo',
       contacto: 'Contacto',
       privacy: 'Privacidad',
       terms: 'Términos',
@@ -23,7 +23,7 @@ function Footer() {
       sobreMi: 'About Me',
       habilidades: 'Skills',
       portafolio: 'Portfolio',
-      servicios: 'Services',
+      servicios: 'How I work',
       contacto: 'Contact',
       privacy: 'Privacy Policy',
       terms: 'Terms of Service',
@@ -46,7 +46,7 @@ function Footer() {
           <Link to="/" onClick={() => handleScrollToElement('sobre-mi')}>{footerLinks[language].sobreMi}</Link>
           <Link to="/" onClick={() => handleScrollToElement('habilidades')}>{footerLinks[language].habilidades}</Link>
           <Link to="/" onClick={() => handleScrollToElement('portafolio')}>{footerLinks[language].portafolio}</Link>
-          <Link to="/" onClick={() => handleScrollToElement('servicios')}>{footerLinks[language].servicios}</Link>
+          <Link to="/" onClick={() => handleScrollToElement('como-trabajo')}>{footerLinks[language].servicios}</Link>
           <Link to="/" onClick={() => handleScrollToElement('contacto')}>{footerLinks[language].contacto}</Link>
           <Link to="/privacy-policy">{footerLinks[language].privacy}</Link>
           <Link to="/terms-of-service">{footerLinks[language].terms}</Link>

--- a/my-app/src/components/Footer.test.js
+++ b/my-app/src/components/Footer.test.js
@@ -1,0 +1,72 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import Footer from './Footer';
+import { LanguageContext } from '../contexts/LanguageContext';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderFooter = (language = 'es') => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <MemoryRouter>
+        <LanguageContext.Provider value={{ language }}>
+          <Footer />
+        </LanguageContext.Provider>
+      </MemoryRouter>
+    );
+  });
+
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    }
+  };
+};
+
+describe('Footer', () => {
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('links Como trabajo to the existing section in Spanish', () => {
+    const target = document.createElement('section');
+    target.id = 'como-trabajo';
+    target.scrollIntoView = jest.fn();
+    document.body.appendChild(target);
+
+    const { container, cleanup } = renderFooter('es');
+    const howIWorkLink = Array.from(container.querySelectorAll('a')).find((link) => link.textContent.includes('Cómo trabajo'));
+
+    expect(howIWorkLink).toBeTruthy();
+    expect(container.textContent).not.toContain('Servicios');
+
+    act(() => {
+      howIWorkLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+    cleanup();
+  });
+
+  it('renders How I work in English', () => {
+    const { container, cleanup } = renderFooter('en');
+
+    expect(container.textContent).toContain('How I work');
+    expect(container.textContent).not.toContain('Services');
+
+    cleanup();
+  });
+});

--- a/my-app/src/components/HeroBanner.js
+++ b/my-app/src/components/HeroBanner.js
@@ -4,8 +4,6 @@ import { ThemeContext } from '../contexts/ThemeContext';
 import heroPortrait from '../assets/images/profile-picture-elier2.png';
 import '../styles/components/HeroBanner.css';
 
-const CALENDLY_URL = 'https://calendly.com/loya-elier/primer-contacto-15-min';
-
 const DynamicHeroBanner = ({ style }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isTransitioning, setIsTransitioning] = useState(false);
@@ -20,7 +18,7 @@ const DynamicHeroBanner = ({ style }) => {
         subtitle: 'Ex-COO de GoFarma y Digital Product Owner en CHUBB.',
         description: 'Estrategia, prototipo y métricas reales para validar, automatizar o destrabar un reto operativo sin humo.',
         icon: '🧪',
-        cta: 'Agenda una llamada',
+        cta: 'Hablemos de tu reto',
         secondaryCta: 'Ver casos reales'
       }
     ],
@@ -30,7 +28,7 @@ const DynamicHeroBanner = ({ style }) => {
         subtitle: 'Ex-COO at GoFarma and Digital Product Owner at CHUBB.',
         description: 'Strategy, prototype and real metrics to validate, automate or unblock an operational challenge without fluff.',
         icon: '🧪',
-        cta: 'Schedule a call',
+        cta: 'Let’s talk about your challenge',
         secondaryCta: 'See real cases'
       }
     ]
@@ -130,9 +128,9 @@ const DynamicHeroBanner = ({ style }) => {
           <h3 className="hero-subtitle">{currentContent?.subtitle}</h3>
           <p className="hero-description">{currentContent?.description}</p>
           <div className="hero-actions" aria-label="Acciones principales">
-            <a className="hero-button" href={CALENDLY_URL} target="_blank" rel="noopener noreferrer">
-              {currentContent?.cta} →
-            </a>
+            <button className="hero-button" onClick={() => scrollToSection('contacto')}>
+              {currentContent?.cta}
+            </button>
             <button className="hero-button-secondary" onClick={() => scrollToSection('casos-reales')}>
               {currentContent?.secondaryCta}
             </button>

--- a/my-app/src/components/HeroBanner.test.js
+++ b/my-app/src/components/HeroBanner.test.js
@@ -4,7 +4,6 @@ import HeroBanner from './HeroBanner';
 import { LanguageContext } from '../contexts/LanguageContext';
 import { ThemeContext } from '../contexts/ThemeContext';
 
-const calendlyUrl = 'https://calendly.com/loya-elier/primer-contacto-15-min';
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
 const renderHero = (language = 'es') => {
@@ -44,7 +43,12 @@ describe('HeroBanner', () => {
     document.body.innerHTML = '';
   });
 
-  it('shows the approved Spanish hero message and Calendly CTA', () => {
+  it('shows the approved Spanish hero message and scroll CTA to contacto', () => {
+    const contacto = document.createElement('section');
+    contacto.id = 'contacto';
+    contacto.scrollIntoView = jest.fn();
+    document.body.appendChild(contacto);
+
     const { container, cleanup } = renderHero('es');
 
     expect(container.textContent).toContain('Transformo procesos complicados en soluciones que realmente funcionan.');
@@ -52,9 +56,15 @@ describe('HeroBanner', () => {
     expect(container.textContent).not.toContain('producto digital funcional en semanas, no meses');
 
     const primaryCta = container.querySelector('.hero-button');
-    expect(primaryCta.textContent).toContain('Agenda una llamada');
-    expect(primaryCta.tagName).toBe('A');
-    expect(primaryCta.getAttribute('href')).toBe(calendlyUrl);
+    expect(primaryCta.textContent).toContain('Hablemos de tu reto');
+    expect(primaryCta.tagName).toBe('BUTTON');
+    expect(container.innerHTML).not.toContain('calendly.com');
+
+    act(() => {
+      primaryCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(contacto.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
 
     const secondaryCta = container.querySelector('.hero-button-secondary');
     expect(secondaryCta.textContent).toContain('Ver casos reales');
@@ -66,7 +76,8 @@ describe('HeroBanner', () => {
     const { container, cleanup } = renderHero('en');
 
     expect(container.textContent).toContain('I turn your business idea into a working digital product in weeks, not months');
-    expect(container.querySelector('.hero-button').textContent).toContain('Schedule a call');
+    expect(container.querySelector('.hero-button').textContent).toContain('Let’s talk about your challenge');
+    expect(container.innerHTML).not.toContain('calendly.com');
 
     cleanup();
   });

--- a/my-app/src/components/Navegacion.js
+++ b/my-app/src/components/Navegacion.js
@@ -50,14 +50,14 @@ function Navegacion() {
       sobreMi: 'Sobre Mí',
       habilidades: 'Habilidades',
       portafolio: 'Carrera',
-      servicios: 'Servicios',
+      servicios: 'Cómo trabajo',
       contactame: ' Contáctame',
     },
     en: {
       sobreMi: 'About Me',
       habilidades: 'Skills',
-      portafolio: 'Carrer',
-      servicios: 'Services',
+      portafolio: 'Career',
+      servicios: 'How I work',
       contactame: ' Contact Me',
     }
   };
@@ -78,8 +78,7 @@ function Navegacion() {
           <li><Link to="/" onClick={() => handleScrollToElement('sobre-mi')}>{navItems[language].sobreMi}</Link></li>
           <li><Link to="/" onClick={() => handleScrollToElement('habilidades')}>{navItems[language].habilidades}</Link></li>
           <li><Link to="/" onClick={() => handleScrollToElement('portafolio')}>{navItems[language].portafolio}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('servicios')}>{navItems[language].servicios}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('sites')}>{navItems[language].sites}</Link></li>
+          <li><Link to="/" onClick={() => handleScrollToElement('como-trabajo')}>{navItems[language].servicios}</Link></li>
           <li>
             <Link
               to="/"

--- a/my-app/src/components/Navegacion.test.js
+++ b/my-app/src/components/Navegacion.test.js
@@ -1,0 +1,74 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import Navegacion from './Navegacion';
+import { LanguageContext } from '../contexts/LanguageContext';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderNavegacion = (language = 'es') => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <MemoryRouter>
+        <LanguageContext.Provider value={{ language }}>
+          <Navegacion />
+        </LanguageContext.Provider>
+      </MemoryRouter>
+    );
+  });
+
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    }
+  };
+};
+
+describe('Navegacion', () => {
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('shows Como trabajo and scrolls to the existing section in Spanish', () => {
+    const target = document.createElement('section');
+    target.id = 'como-trabajo';
+    target.scrollIntoView = jest.fn();
+    document.body.appendChild(target);
+
+    const { container, cleanup } = renderNavegacion('es');
+    const howIWorkLink = Array.from(container.querySelectorAll('a')).find((link) => link.textContent.includes('Cómo trabajo'));
+
+    expect(howIWorkLink).toBeTruthy();
+    expect(container.textContent).not.toContain('Servicios');
+    expect(container.querySelectorAll('li')).toHaveLength(6);
+
+    act(() => {
+      howIWorkLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+    cleanup();
+  });
+
+  it('shows How I work and fixes Career in English', () => {
+    const { container, cleanup } = renderNavegacion('en');
+
+    expect(container.textContent).toContain('How I work');
+    expect(container.textContent).toContain('Career');
+    expect(container.textContent).not.toContain('Carrer');
+
+    cleanup();
+  });
+});

--- a/my-app/src/components/Portafolio.js
+++ b/my-app/src/components/Portafolio.js
@@ -222,14 +222,14 @@ const Portafolio = ({ style }) => {
       description:
         'Trabajemos juntos para diseñar una solución a medida, desde la estrategia hasta la implementación.',
       primary: 'Solicitar una reunión',
-      secondary: 'Revisar servicios disponibles'
+      secondary: 'Conoce cómo trabajo'
     },
     en: {
       title: 'Ready to see your project featured here?',
       description:
         'Let’s craft a tailored solution together—from strategic planning to hands-on implementation.',
       primary: 'Request a meeting',
-      secondary: 'Review available services'
+      secondary: 'See how I work'
     }
   };
 
@@ -317,7 +317,7 @@ const Portafolio = ({ style }) => {
           </button>
           <button
             className="cta-button-secondary"
-            onClick={() => handleScrollToSection('servicios')}
+            onClick={() => handleScrollToSection('como-trabajo')}
           >
             {currentCta.secondary}
           </button>

--- a/my-app/src/components/Portafolio.test.js
+++ b/my-app/src/components/Portafolio.test.js
@@ -1,0 +1,71 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import Portafolio from './Portafolio';
+import { LanguageContext } from '../contexts/LanguageContext';
+
+jest.mock('./utils/languageUtils', () => ({
+  getCurrentLanguage: jest.fn(() => 'es')
+}));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderPortafolio = (language = 'es') => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <LanguageContext.Provider value={{ language }}>
+        <Portafolio />
+      </LanguageContext.Provider>
+    );
+  });
+
+  return {
+    container,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    }
+  };
+};
+
+describe('Portafolio CTA', () => {
+  beforeEach(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  it('points the secondary CTA to como-trabajo in Spanish', () => {
+    const target = document.createElement('section');
+    target.id = 'como-trabajo';
+    target.scrollIntoView = jest.fn();
+    document.body.appendChild(target);
+
+    const { container, cleanup } = renderPortafolio('es');
+    const secondaryCta = container.querySelector('.cta-button-secondary');
+
+    expect(secondaryCta.textContent).toContain('Conoce cómo trabajo');
+
+    act(() => {
+      secondaryCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+    cleanup();
+  });
+
+  it('renders the approved English secondary CTA copy', () => {
+    const { container, cleanup } = renderPortafolio('en');
+
+    expect(container.querySelector('.cta-button-secondary').textContent).toContain('See how I work');
+
+    cleanup();
+  });
+});

--- a/my-app/src/components/Servicios.js
+++ b/my-app/src/components/Servicios.js
@@ -7,7 +7,7 @@ function Servicios({ style }) {
 
   const content = {
     es: {
-      heading: 'Mi método',
+      heading: 'Cómo trabajo',
       intro: 'Filtro sin rodeos: trabajo mejor con retos acotados, métricas claras y entregas visibles.',
       blocks: [
         {
@@ -31,7 +31,7 @@ function Servicios({ style }) {
       ctaHelper: 'No tomo proyectos sin foco; sí tomo problemas que podemos mover rápido.'
     },
     en: {
-      heading: 'My method',
+      heading: 'How I work',
       intro: 'Clear filter: I work best with scoped challenges, clear metrics and visible delivery.',
       blocks: [
         {
@@ -59,7 +59,7 @@ function Servicios({ style }) {
   const t = content[language] || content.es;
 
   return (
-    <section id="disponibilidad" className="servicios colaboraciones disponibilidad" style={style}>
+    <section id="como-trabajo" className="servicios colaboraciones disponibilidad" style={{ scrollMarginTop: '96px', ...style }}>
       <div className="servicios-header">
         <h1>{t.heading}</h1>
       </div>


### PR DESCRIPTION
## Resumen de cambios
- Reemplacé el CTA principal del hero para que haga scroll a `#contacto` y eliminé la dependencia pública de Calendly.
- Alineé navegación y CTAs públicos hacia `#como-trabajo`, renombrando la sección visible a `Cómo trabajo / How I work`.
- Quité la flecha decorativa de `CasosEstudio` y eliminé el enlace público a Calendly en contacto, dejando el CV como PDF en nueva pestaña.
- Corregí también el footer porque seguía publicando `Servicios/Services` hacia un ancla inexistente.

## Archivos modificados
- `my-app/src/components/HeroBanner.js`
- `my-app/src/components/HeroBanner.test.js`
- `my-app/src/components/Contacto.js`
- `my-app/src/components/Contacto.test.js`
- `my-app/src/components/Navegacion.js`
- `my-app/src/components/Navegacion.test.js`
- `my-app/src/components/Portafolio.js`
- `my-app/src/components/Portafolio.test.js`
- `my-app/src/components/Servicios.js`
- `my-app/src/components/CasosEstudio.js`
- `my-app/src/components/CasosEstudio.test.js`
- `my-app/src/components/Footer.js`
- `my-app/src/components/Footer.test.js`

## Pruebas ejecutadas y resultado
- `npm test -- --runInBand src/components/HeroBanner.test.js src/components/Contacto.test.js src/components/Navegacion.test.js src/components/Portafolio.test.js src/components/CasosEstudio.test.js src/components/Footer.test.js --watchAll=false` ✅
- `npm run build` ⚠️ falló en esta máquina por `EPERM/ENOTEMPTY` sobre archivos bloqueados dentro de `my-app/build/static/media` (`ecommerce_marketing...png`, `technologic_vision...png`).
- `git diff --check` ✅ sin errores de whitespace; solo warnings de LF→CRLF del repo.

## Confirmación de QA manual
Validé navegación e interacción real sobre una build alternativa de producción (`build-codex`) servida localmente porque el `build/` estándar quedó bloqueado por Windows.
- Desktop 1440px: claro/español y oscuro/inglés.
- Mobile 390x844: oscuro/inglés y claro/español.
- Revisado: hero CTA → contacto, hero secundario → casos reales, nav y footer → `#como-trabajo`, CTA secundario de carrera → `#como-trabajo`, CV en nueva pestaña, ausencia de links a Calendly, ausencia de overflow horizontal y persistencia de diagnóstico/contacto/casos.

## Riesgos o deuda detectada
- El flujo exacto `npm run build` sigue bloqueado por un lock ambiental en `my-app/build/static/media`; no es un error de compilación del código modificado, pero sí impide cerrar esa compuerta exacta en este entorno sin liberar ese directorio.
- El script post-build del repo está acoplado a `build/index.html`, por eso una ruta alternativa solo sirve como verificación manual, no como reemplazo del comando exacto.

## Confirmación de no alcance
No modifiqué diagnóstico, backend, servicios comerciales, SEO global, sitemap, robots, rutas, dependencias ni configuración de despliegue. Tampoco dejé cambios en `hashedPasscodes.js`.
