### PR TITLE
[codex] fix cases navigation labels

### DIFF
--- a/my-app/src/components/Footer.js
+++ b/my-app/src/components/Footer.js
@@ -10,8 +10,8 @@ function Footer() {
     es: {
       inicio: 'Inicio',
       sobreMi: 'Sobre Mí',
-      habilidades: 'Habilidades',
-      portafolio: 'Portafolio',
+      casosReales: 'Casos reales',
+      portafolio: 'Carrera',
       soluciones: 'Soluciones',
       contacto: 'Contacto',
       privacy: 'Privacidad',
@@ -21,8 +21,8 @@ function Footer() {
     en: {
       inicio: 'Home',
       sobreMi: 'About Me',
-      habilidades: 'Skills',
-      portafolio: 'Portfolio',
+      casosReales: 'Case studies',
+      portafolio: 'Career',
       soluciones: 'Solutions',
       contacto: 'Contact',
       privacy: 'Privacy Policy',
@@ -44,7 +44,7 @@ function Footer() {
         <div className="footer-links">
           <Link to="/" onClick={() => handleScrollToElement('hero-banner')}><i className="fas fa-home"></i></Link>
           <Link to="/" onClick={() => handleScrollToElement('sobre-mi')}>{footerLinks[language].sobreMi}</Link>
-          <Link to="/" onClick={() => handleScrollToElement('habilidades')}>{footerLinks[language].habilidades}</Link>
+          <Link to="/" onClick={() => handleScrollToElement('casos-reales')}>{footerLinks[language].casosReales}</Link>
           <Link to="/" onClick={() => handleScrollToElement('portafolio')}>{footerLinks[language].portafolio}</Link>
           <Link to="/" onClick={() => handleScrollToElement('soluciones')}>{footerLinks[language].soluciones}</Link>
           <Link to="/" onClick={() => handleScrollToElement('contacto')}>{footerLinks[language].contacto}</Link>

--- a/my-app/src/components/Footer.test.js
+++ b/my-app/src/components/Footer.test.js
@@ -30,6 +30,8 @@ const renderFooter = (language = 'es') => {
   };
 };
 
+const findLinkByText = (container, text) => Array.from(container.querySelectorAll('a')).find((link) => link.textContent.includes(text));
+
 describe('Footer', () => {
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
@@ -40,33 +42,71 @@ describe('Footer', () => {
     document.body.innerHTML = '';
   });
 
-  it('links Soluciones to the solutions section in Spanish', () => {
-    const target = document.createElement('section');
-    target.id = 'soluciones';
-    target.scrollIntoView = jest.fn();
-    document.body.appendChild(target);
+  it('links Casos reales / Case studies to the cases section', () => {
+    ['es', 'en'].forEach((language) => {
+      const target = document.createElement('section');
+      target.id = 'casos-reales';
+      target.scrollIntoView = jest.fn();
+      document.body.appendChild(target);
 
-    const { container, cleanup } = renderFooter('es');
-    const solutionsLink = Array.from(container.querySelectorAll('a')).find((link) => link.textContent.includes('Soluciones'));
+      const { container, cleanup } = renderFooter(language);
+      const label = language === 'es' ? 'Casos reales' : 'Case studies';
+      const casesLink = findLinkByText(container, label);
 
-    expect(solutionsLink).toBeTruthy();
-    expect(container.textContent).not.toContain('Cómo trabajo');
+      expect(casesLink).toBeTruthy();
 
-    act(() => {
-      solutionsLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      act(() => {
+        casesLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+      cleanup();
+      target.remove();
     });
-
-    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
-
-    cleanup();
   });
 
-  it('renders Solutions in English', () => {
-    const { container, cleanup } = renderFooter('en');
+  it('shows Carrera / Career and removes the old Habilidades / Skills and Portafolio / Portfolio labels', () => {
+    const { container: esContainer, cleanup: cleanupEs } = renderFooter('es');
+    expect(esContainer.textContent).toContain('Carrera');
+    expect(esContainer.textContent).not.toContain('Habilidades');
+    expect(esContainer.textContent).not.toContain('Portafolio');
+    cleanupEs();
 
-    expect(container.textContent).toContain('Solutions');
-    expect(container.textContent).not.toContain('How I work');
-    expect(container.textContent).not.toContain('Services');
+    const { container: enContainer, cleanup: cleanupEn } = renderFooter('en');
+    expect(enContainer.textContent).toContain('Career');
+    expect(enContainer.textContent).not.toContain('Skills');
+    expect(enContainer.textContent).not.toContain('Portfolio');
+    cleanupEn();
+  });
+
+  it('keeps Soluciones, Contacto and Sobre Mí working', () => {
+    const targets = ['sobre-mi', 'soluciones', 'contacto'].reduce((acc, id) => {
+      const target = document.createElement('section');
+      target.id = id;
+      target.scrollIntoView = jest.fn();
+      document.body.appendChild(target);
+      acc[id] = target;
+      return acc;
+    }, {});
+
+    const { container, cleanup } = renderFooter('es');
+    const aboutLink = findLinkByText(container, 'Sobre Mí');
+    const solutionsLink = findLinkByText(container, 'Soluciones');
+    const contactLink = findLinkByText(container, 'Contacto');
+
+    expect(aboutLink).toBeTruthy();
+    expect(solutionsLink).toBeTruthy();
+    expect(contactLink).toBeTruthy();
+    act(() => {
+      aboutLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      solutionsLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      contactLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(targets['sobre-mi'].scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(targets['soluciones'].scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(targets['contacto'].scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
 
     cleanup();
   });

--- a/my-app/src/components/Navegacion.js
+++ b/my-app/src/components/Navegacion.js
@@ -48,14 +48,14 @@ function Navegacion() {
   const navItems = {
     es: {
       sobreMi: 'Sobre Mí',
-      habilidades: 'Habilidades',
+      casosReales: 'Casos reales',
       portafolio: 'Carrera',
       soluciones: 'Soluciones',
       contactame: ' Contáctame',
     },
     en: {
       sobreMi: 'About Me',
-      habilidades: 'Skills',
+      casosReales: 'Case studies',
       portafolio: 'Career',
       soluciones: 'Solutions',
       contactame: ' Contact Me',
@@ -76,7 +76,7 @@ function Navegacion() {
         <ul className={`nav-links ${menuOpen ? 'open' : ''}`}>
           <li><Link to="/" onClick={() => handleScrollToElement('hero-banner')}><i className="fas fa-home"></i></Link></li>
           <li><Link to="/" onClick={() => handleScrollToElement('sobre-mi')}>{navItems[language].sobreMi}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('habilidades')}>{navItems[language].habilidades}</Link></li>
+          <li><Link to="/" onClick={() => handleScrollToElement('casos-reales')}>{navItems[language].casosReales}</Link></li>
           <li><Link to="/" onClick={() => handleScrollToElement('portafolio')}>{navItems[language].portafolio}</Link></li>
           <li><Link to="/" onClick={() => handleScrollToElement('soluciones')}>{navItems[language].soluciones}</Link></li>
           <li>

--- a/my-app/src/components/Navegacion.test.js
+++ b/my-app/src/components/Navegacion.test.js
@@ -30,6 +30,8 @@ const renderNavegacion = (language = 'es') => {
   };
 };
 
+const findLinkByText = (container, text) => Array.from(container.querySelectorAll('a')).find((link) => link.textContent.includes(text));
+
 describe('Navegacion', () => {
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
@@ -40,21 +42,66 @@ describe('Navegacion', () => {
     document.body.innerHTML = '';
   });
 
-  it('shows Soluciones and scrolls to the solutions section in Spanish', () => {
+  it('shows Casos reales in Spanish and keeps the existing destinations working', () => {
+    const targets = ['sobre-mi', 'casos-reales', 'soluciones', 'contacto'].reduce((acc, id) => {
+      const target = document.createElement('section');
+      target.id = id;
+      target.scrollIntoView = jest.fn();
+      document.body.appendChild(target);
+      acc[id] = target;
+      return acc;
+    }, {});
+
+    const { container, cleanup } = renderNavegacion('es');
+    const casesLink = findLinkByText(container, 'Casos reales');
+    const aboutLink = findLinkByText(container, 'Sobre Mí');
+    const solutionsLink = findLinkByText(container, 'Soluciones');
+    const contactLink = findLinkByText(container, 'Contáctame');
+
+    expect(casesLink).toBeTruthy();
+    expect(aboutLink).toBeTruthy();
+    expect(solutionsLink).toBeTruthy();
+    expect(contactLink).toBeTruthy();
+    expect(container.textContent).toContain('Casos reales');
+    expect(container.textContent).toContain('Carrera');
+    expect(container.textContent).toContain('Sobre Mí');
+    expect(container.textContent).toContain('Soluciones');
+    expect(container.textContent).toContain('Contáctame');
+    expect(container.textContent).not.toContain('Habilidades');
+    expect(container.textContent).not.toContain('Portafolio');
+
+    act(() => {
+      casesLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      aboutLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      solutionsLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      contactLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(targets['casos-reales'].scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(targets['sobre-mi'].scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(targets['soluciones'].scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(targets['contacto'].scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+    cleanup();
+  });
+
+  it('shows Case studies in English and scrolls to the cases section', () => {
     const target = document.createElement('section');
-    target.id = 'soluciones';
+    target.id = 'casos-reales';
     target.scrollIntoView = jest.fn();
     document.body.appendChild(target);
 
-    const { container, cleanup } = renderNavegacion('es');
-    const solutionsLink = Array.from(container.querySelectorAll('a')).find((link) => link.textContent.includes('Soluciones'));
+    const { container, cleanup } = renderNavegacion('en');
+    const casesLink = findLinkByText(container, 'Case studies');
 
-    expect(solutionsLink).toBeTruthy();
-    expect(container.textContent).not.toContain('Cómo trabajo');
-    expect(container.querySelectorAll('li')).toHaveLength(6);
+    expect(casesLink).toBeTruthy();
+    expect(container.textContent).toContain('Case studies');
+    expect(container.textContent).toContain('Career');
+    expect(container.textContent).not.toContain('Skills');
+    expect(container.textContent).not.toContain('Portfolio');
 
     act(() => {
-      solutionsLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      casesLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
     expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
@@ -62,13 +109,32 @@ describe('Navegacion', () => {
     cleanup();
   });
 
-  it('shows Solutions and fixes Career in English', () => {
-    const { container, cleanup } = renderNavegacion('en');
+  it('closes the mobile menu after selecting Casos reales', () => {
+    const target = document.createElement('section');
+    target.id = 'casos-reales';
+    target.scrollIntoView = jest.fn();
+    document.body.appendChild(target);
 
-    expect(container.textContent).toContain('Solutions');
-    expect(container.textContent).toContain('Career');
-    expect(container.textContent).not.toContain('How I work');
-    expect(container.textContent).not.toContain('Carrer');
+    const { container, cleanup } = renderNavegacion('es');
+    const menuToggle = container.querySelector('.menu-toggle');
+    const navLinks = container.querySelector('.nav-links');
+    const casesLink = findLinkByText(container, 'Casos reales');
+
+    expect(menuToggle).toBeTruthy();
+    expect(navLinks).toBeTruthy();
+    expect(casesLink).toBeTruthy();
+    act(() => {
+      menuToggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(navLinks.classList.contains('open')).toBe(true);
+
+    act(() => {
+      casesLink.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(navLinks.classList.contains('open')).toBe(false);
 
     cleanup();
   });


### PR DESCRIPTION
## What changed
- Replaced the public `Habilidades / Skills` navigation entry with `Casos reales / Case studies`.
- Kept the existing `Link to="/"` scroll pattern and pointed the new entry at `#casos-reales`.
- Aligned the footer career label to `Carrera / Career` while preserving the `#portafolio` destination.

## Why
- The public navigation should send visitors to concrete work evidence instead of a standalone skills section.
- The footer and navbar labels now match each other.

## Validation
- `npm test -- --runInBand src/components/Navegacion.test.js src/components/Footer.test.js --watchAll=false`
- `npm run build`
- `git diff --check`