### PR TITLE
[codex] Redesign contact conversation UX

### DIFF
--- a/my-app/src/components/Contacto.js
+++ b/my-app/src/components/Contacto.js
@@ -1,230 +1,253 @@
 // Contacto.js
 
-import React, { useState, useEffect } from 'react';
-import { useLanguage } from '../contexts/LanguageContext';
-import CV from '../assets/files/2409_CV_EL.pdf';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import '../styles/components/Contacto.css';
-import perfilImg from '../assets/images/profile-picture-elier2.png';
 import { useLocation } from 'react-router-dom';
+import { useLanguage } from '../contexts/LanguageContext';
+import perfilImg from '../assets/images/profile-picture-elier2.png';
+import '../styles/components/Contacto.css';
+
+const CONTACT_ENDPOINT = 'https://81ocg9.buildship.run/contact_me';
+const EMAIL = 'loya.elier@gmail.com';
+const WHATSAPP_URL = 'https://wa.me/528117801157';
+const LINKEDIN_URL = 'https://linkedin.com/in/elier/';
+const GITHUB_URL = 'https://github.com/elelier';
 
 const texts = {
   es: {
-    contactTitle: 'Contáctame',
-    contactPhrase: '¡Estoy aquí para ayudarte! No dudes en ponerte en contacto.',
-    successMessage: 'Tu mensaje ha sido enviado correctamente, gracias por tu interés.',
-    errorMessage: 'Hubo un problema al enviar tu mensaje. Por favor, intenta nuevamente.',
-    networkError: 'Error en la red. Por favor, intenta nuevamente.',
-    contactInfo: 'Información de contacto',
-    email: 'loya.elier@gmail.com',
-    whatsapp: 'Envíame un mensaje',
-    location: 'Monterrey, México',
-    professionalLinks: 'Enlaces Profesionales',
-    downloadCV: 'Ver CV (PDF)',
+    eyebrow: 'Hablemos',
+    title: 'Cuéntame qué quieres mejorar',
+    description:
+      'Comparte el reto, proceso o idea que quieres mover. Te responderé personalmente para entender el contexto y ver si hace sentido trabajar juntos.',
+    directLabel: 'Ruta directa',
+    whatsappButton: 'Escríbeme por WhatsApp',
+    whatsappHelper: 'Ideal para una primera conversación rápida.',
+    formTitle: 'O déjame un poco de contexto',
+    nameLabel: 'Tu nombre',
+    emailLabel: 'Tu correo',
+    messageLabel: '¿Qué quieres mejorar, automatizar, simplificar, digitalizar o crear?',
+    submitButton: 'Enviar mensaje',
+    submittingButton: 'Enviando mensaje…',
+    microcopy: 'Sin diagnóstico automático ni agenda obligatoria. Empezamos por el reto.',
+    successMessage: 'Gracias, ya recibí tu mensaje. Te responderé personalmente.',
+    errorMessage: 'No pude enviar tu mensaje en este momento. Puedes escribirme por WhatsApp o correo.',
+    findMeTitle: 'También puedes encontrarme en',
+    location: 'Monterrey, México · Trabajo remoto',
     linkedin: 'LinkedIn',
     github: 'GitHub',
-    namePlaceholder: 'Nombre',
-    emailPlaceholder: 'Correo electrónico',
-    messagePlaceholder: 'Mensaje'
+    quotePrefill: 'Hola, me gustaría solicitar una cotización.'
   },
   en: {
-    contactTitle: 'Contact Me',
-    contactPhrase: 'I’m here to help! Feel free to get in touch.',
-    successMessage: 'Your message has been sent successfully, thank you for your interest.',
-    errorMessage: 'There was a problem sending your message. Please try again.',
-    networkError: 'Network error. Please try again.',
-    contactInfo: 'Contact Information',
-    email: 'loya.elier@gmail.com',
-    whatsapp: 'Message Me',
-    location: 'Monterrey, Mexico',
-    professionalLinks: 'Professional Links',
-    downloadCV: 'View resume (PDF)',
+    eyebrow: 'Let’s talk',
+    title: 'Tell me what you want to improve',
+    description:
+      'Share the challenge, process or idea you want to move forward. I will reply personally to understand the context and see whether it makes sense to work together.',
+    directLabel: 'Direct route',
+    whatsappButton: 'Message me on WhatsApp',
+    whatsappHelper: 'Best for a quick first conversation.',
+    formTitle: 'Or send me some context',
+    nameLabel: 'Your name',
+    emailLabel: 'Your email',
+    messageLabel: 'What do you want to improve, automate, simplify, digitize or create?',
+    submitButton: 'Send message',
+    submittingButton: 'Sending message…',
+    microcopy: 'No automatic diagnosis or mandatory scheduling. We start with the challenge.',
+    successMessage: 'Thanks, I received your message. I will reply personally.',
+    errorMessage: 'I could not send your message right now. You can reach me through WhatsApp or email.',
+    findMeTitle: 'You can also find me on',
+    location: 'Monterrey, Mexico · Remote work',
     linkedin: 'LinkedIn',
     github: 'GitHub',
-    namePlaceholder: 'Name',
-    emailPlaceholder: 'Email',
-    messagePlaceholder: 'Message'
+    quotePrefill: 'Hi, I would like to request a quote.'
   }
 };
 
 function Contacto({ style }) {
   const { language } = useLanguage();
-  const t = texts[language] || texts.en; // Default to English if language is not found
+  const t = texts[language] || texts.en;
+  const location = useLocation();
 
   const [name, setName] = useState('');
   const [mail, setMail] = useState('');
   const [message, setMessage] = useState('');
-  const [successMessage, setSuccessMessage] = useState('');
-  const [errorMessage, setErrorMessage] = useState('');
-  const location = useLocation();
+  const [feedback, setFeedback] = useState({ type: '', message: '' });
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     if (params.get('subject') === 'quote' && message === '') {
-      const quoteText =
-        language === 'es'
-          ? 'Hola, me gustaría solicitar una cotización.'
-          : 'Hi, I would like to request a quote.';
-      setMessage(quoteText);
+      setMessage(t.quotePrefill);
     }
-  }, [location.search, language, message]);
+  }, [location.search, message, t.quotePrefill]);
 
+  const handleSubmit = async (event) => {
+    event.preventDefault();
 
-  const handleSubmit = async (e) => {
-    e.preventDefault();
+    if (isSubmitting) {
+      return;
+    }
+
+    setFeedback({ type: '', message: '' });
+    setIsSubmitting(true);
 
     try {
-      const response = await fetch('https://81ocg9.buildship.run/contact_me', {
+      const response = await fetch(CONTACT_ENDPOINT, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ name, mail, message }),
+        body: JSON.stringify({ name, mail, message })
       });
 
-      if (response.ok) {
-        setSuccessMessage(t.successMessage);
-        setName('');
-        setMail('');
-        setMessage('');
-      } else {
-        setErrorMessage(t.errorMessage);
+      if (!response.ok) {
+        throw new Error('Contact request failed');
       }
+
+      setFeedback({ type: 'success', message: t.successMessage });
+      setName('');
+      setMail('');
+      setMessage('');
     } catch (error) {
-      setErrorMessage(t.networkError);
+      setFeedback({ type: 'error', message: t.errorMessage });
+    } finally {
+      setIsSubmitting(false);
     }
   };
+
+  const feedbackClassName = feedback.type ? `contacto-feedback contacto-feedback--${feedback.type}` : 'contacto-feedback';
 
   return (
     <motion.section
       id="contacto"
       className="contacto"
       style={{ scrollMarginTop: '96px', ...style }}
-      initial={{ opacity: 0, y: 50 }}
+      initial={{ opacity: 0, y: 32 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5 }}
+      transition={{ duration: 0.5, ease: 'easeOut' }}
     >
-      <div className="contacto">
-        <div className="contacto-header">
-          <img src={perfilImg} alt="Perfil" className="contacto-imagen" />
-          <div className="contacto-titulo">
-            <h2>{t.contactTitle}</h2>
-            <p className="contacto-frase">{t.contactPhrase}</p>
+      <div className="contacto-shell">
+        <div className="contacto-heading">
+          <div>
+            <p className="contacto-eyebrow">{t.eyebrow}</p>
+            <h2>{t.title}</h2>
           </div>
+          <p>{t.description}</p>
         </div>
-        <div className="contacto-contenido">
+
+        <div className="contacto-layout">
+          <aside className="contacto-conversation" aria-label={t.directLabel}>
+            <div className="contacto-profile">
+              <img src={perfilImg} alt="Elier Loya" className="contacto-imagen" />
+              <div>
+                <p className="contacto-route-label">{t.directLabel}</p>
+                <a href={WHATSAPP_URL} target="_blank" rel="noopener noreferrer" className="contacto-whatsapp">
+                  <i className="fab fa-whatsapp" aria-hidden="true"></i>
+                  <span>{t.whatsappButton}</span>
+                </a>
+                <p className="contacto-helper">{t.whatsappHelper}</p>
+              </div>
+            </div>
+
+            <div className="contacto-secondary">
+              <h3>{t.findMeTitle}</h3>
+              <ul>
+                <li>
+                  <a href={`mailto:${EMAIL}`}>
+                    <i className="fas fa-envelope" aria-hidden="true"></i>
+                    <span>{EMAIL}</span>
+                  </a>
+                </li>
+                <li className="contacto-location">
+                  <i className="fas fa-location-dot" aria-hidden="true"></i>
+                  <span>{t.location}</span>
+                </li>
+                <li>
+                  <a href={LINKEDIN_URL} target="_blank" rel="noopener noreferrer">
+                    <i className="fab fa-linkedin" aria-hidden="true"></i>
+                    <span>{t.linkedin}</span>
+                  </a>
+                </li>
+                <li>
+                  <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+                    <i className="fab fa-github" aria-hidden="true"></i>
+                    <span>{t.github}</span>
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </aside>
+
           <form className="formulario-contacto" onSubmit={handleSubmit}>
-            <AnimatedInput
-              placeholder={t.namePlaceholder}
-              type="text"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              maxLength={255}
-            />
-            <AnimatedInput
-              placeholder={t.emailPlaceholder}
-              type="email"
-              value={mail}
-              onChange={(e) => setMail(e.target.value)}
-              maxLength={255}
-            />
-            <AnimatedInput
-              placeholder={t.messagePlaceholder}
-              type="textarea"
-              value={message}
-              onChange={(e) => setMessage(e.target.value)}
-              special
-              maxLength={500}
-            />
-            <motion.button
-              type="submit"
-              whileHover={{ scale: 1.1 }}
-              whileTap={{ scale: 0.95 }}
-            >
-              {language === 'es' ? 'Enviar mensaje' : 'Send Message'}
-            </motion.button>
-            <div className='buttonmessage'>
-              {successMessage && <p className="success-message">{successMessage}</p>}
-              {errorMessage && <p className="error-message">{errorMessage}</p>}
+            <div className="contacto-form-heading">
+              <h3>{t.formTitle}</h3>
+              <p>{t.microcopy}</p>
+            </div>
+
+            <div className="contacto-field">
+              <label htmlFor="contact-name">{t.nameLabel}</label>
+              <input
+                id="contact-name"
+                name="name"
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                required
+                autoComplete="name"
+                maxLength={255}
+              />
+            </div>
+
+            <div className="contacto-field">
+              <label htmlFor="contact-mail">{t.emailLabel}</label>
+              <input
+                id="contact-mail"
+                name="mail"
+                type="email"
+                value={mail}
+                onChange={(event) => setMail(event.target.value)}
+                required
+                autoComplete="email"
+                maxLength={255}
+              />
+            </div>
+
+            <div className="contacto-field">
+              <label htmlFor="contact-message">{t.messageLabel}</label>
+              <textarea
+                id="contact-message"
+                name="message"
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                required
+                autoComplete="off"
+                rows="5"
+                maxLength={500}
+              />
+            </div>
+
+            <button className="contacto-submit" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? t.submittingButton : t.submitButton}
+            </button>
+
+            <div className={feedbackClassName} aria-live="polite">
+              {feedback.message && (
+                <>
+                  <p>{feedback.message}</p>
+                  {feedback.type === 'error' && (
+                    <div className="contacto-feedback-links">
+                      <a href={WHATSAPP_URL} target="_blank" rel="noopener noreferrer">
+                        WhatsApp
+                      </a>
+                      <a href={`mailto:${EMAIL}`}>{EMAIL}</a>
+                    </div>
+                  )}
+                </>
+              )}
             </div>
           </form>
-          <div className="info-contacto">
-            <h3>{t.contactInfo}</h3>
-            <div className="info-contacto-links">
-              <a href={`mailto:${t.email}`} className="info-contacto-link">
-                <i className="fas fa-envelope"></i>
-                {t.email}
-              </a>
-              <a href="https://www.google.com/maps/search/?api=1&query=Monterrey,+México" target="_blank" rel="noopener noreferrer" className="info-contacto-link">
-                <i className="fas fa-map-marker-alt"></i>
-                {t.location}
-              </a>
-            </div>
-            <div className="redes-sociales">
-              <h3>{t.professionalLinks}</h3>
-              <div className="redes-sociales-links">
-                <a href="https://linkedin.com/in/elier/" target="_blank" rel="noopener noreferrer" className="redes-sociales-link">
-                  <i className="fab fa-linkedin"></i>
-                  {t.linkedin}
-                </a>
-                <a href="https://github.com/elelier" target="_blank" rel="noopener noreferrer" className="redes-sociales-link">
-                  <i className="fab fa-github"></i>
-                  {t.github}
-                </a>
-              </div>
-              <div className="agenda-documentos-links">
-                <a href={CV} target="_blank" rel="noopener noreferrer" className="agenda-documentos-link">
-                  <i className="fas fa-file-pdf"></i>
-                  {t.downloadCV}
-                </a>
-              </div>
-            </div>
-          </div>
         </div>
       </div>
     </motion.section>
-  );
-}
-
-function AnimatedInput({ placeholder, type, special, value, onChange, maxLength }) {
-  const [isFocused, setIsFocused] = useState(false);
-
-  return (
-    <div className={`input-container ${special ? 'special' : ''}`}>
-      <motion.label
-        className="input-placeholder"
-        initial={false}
-        animate={{
-          scale: isFocused ? 0.8 : 1,
-          x: 10,
-          y: isFocused ? (special ? -60 : -20) : 0,
-        }}
-        transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-      >
-        {placeholder}
-      </motion.label>
-      {type === 'textarea' ? (
-        <motion.textarea
-          className="input-field textarea-field"
-          value={value}
-          onChange={onChange}
-          onFocus={() => setIsFocused(true)}
-          onBlur={(e) => !e.target.value && setIsFocused(false)}
-          rows="4" // Define el número de filas visibles
-          maxLength={maxLength} // Limita la cantidad de caracteres
-        />
-      ) : (
-        <motion.input
-          type={type}
-          className="input-field"
-          value={value}
-          onChange={onChange}
-          onFocus={() => setIsFocused(true)}
-          onBlur={(e) => !e.target.value && setIsFocused(false)}
-          maxLength={maxLength} // Limita la cantidad de caracteres
-        />
-      )}
-    </div>
   );
 }
 

--- a/my-app/src/components/Contacto.test.js
+++ b/my-app/src/components/Contacto.test.js
@@ -6,14 +6,29 @@ import { LanguageContext } from '../contexts/LanguageContext';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
-const renderContacto = (language = 'es') => {
+const CONTACT_ENDPOINT = 'https://81ocg9.buildship.run/contact_me';
+const WHATSAPP_URL = 'https://wa.me/528117801157';
+const EMAIL = 'loya.elier@gmail.com';
+
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const renderContacto = (language = 'es', initialRoute = '/') => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
 
   act(() => {
     root.render(
-      <MemoryRouter>
+      <MemoryRouter initialEntries={[initialRoute]}>
         <LanguageContext.Provider value={{ language }}>
           <Contacto />
         </LanguageContext.Provider>
@@ -30,33 +45,250 @@ const renderContacto = (language = 'es') => {
   };
 };
 
+const getFieldByLabel = (container, labelText) => {
+  const label = Array.from(container.querySelectorAll('label')).find((item) => item.textContent === labelText);
+  if (!label) {
+    throw new Error(`Missing label: ${labelText}`);
+  }
+
+  const control = container.querySelector(`#${label.getAttribute('for')}`);
+  if (!control) {
+    throw new Error(`Missing control for label: ${labelText}`);
+  }
+
+  return control;
+};
+
+const setFieldValue = (field, value) => {
+  act(() => {
+    const prototype = field.tagName === 'TEXTAREA' ? window.HTMLTextAreaElement.prototype : window.HTMLInputElement.prototype;
+    const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value').set;
+    valueSetter.call(field, value);
+    field.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+};
+
+const submitForm = (container) => {
+  act(() => {
+    container.querySelector('form').dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  });
+};
+
 describe('Contacto', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
   afterEach(() => {
+    jest.restoreAllMocks();
     document.body.innerHTML = '';
   });
 
-  it('removes public Calendly references and exposes the resume as a safe PDF link in Spanish', () => {
+  it('renders the full approved Spanish conversation copy', () => {
     const { container, cleanup } = renderContacto('es');
 
-    expect(container.textContent).not.toContain('Agenda 15 minutos');
-    expect(container.textContent).not.toContain('Agenda y Documentos');
-    expect(container.innerHTML).not.toContain('calendly.com');
-
-    const resumeLink = Array.from(container.querySelectorAll('a')).find((link) => link.textContent.includes('Ver CV (PDF)'));
-
-    expect(resumeLink).toBeTruthy();
-    expect(resumeLink.getAttribute('target')).toBe('_blank');
-    expect(resumeLink.getAttribute('rel')).toBe('noopener noreferrer');
-    expect(resumeLink.hasAttribute('download')).toBe(false);
+    expect(container.textContent).toContain('Hablemos');
+    expect(container.textContent).toContain('Cuéntame qué quieres mejorar');
+    expect(container.textContent).toContain(
+      'Comparte el reto, proceso o idea que quieres mover. Te responderé personalmente para entender el contexto y ver si hace sentido trabajar juntos.'
+    );
+    expect(container.textContent).toContain('Ruta directa');
+    expect(container.textContent).toContain('Escríbeme por WhatsApp');
+    expect(container.textContent).toContain('Ideal para una primera conversación rápida.');
+    expect(container.textContent).toContain('O déjame un poco de contexto');
+    expect(container.textContent).toContain('Sin diagnóstico automático ni agenda obligatoria. Empezamos por el reto.');
+    expect(container.textContent).toContain('También puedes encontrarme en');
+    expect(container.textContent).toContain('Monterrey, México · Trabajo remoto');
 
     cleanup();
   });
 
-  it('renders the approved English resume copy', () => {
+  it('renders the full approved English conversation copy', () => {
     const { container, cleanup } = renderContacto('en');
 
-    expect(container.textContent).not.toContain('Schedule 15 minutes');
-    expect(container.textContent).toContain('View resume (PDF)');
+    expect(container.textContent).toContain('Let’s talk');
+    expect(container.textContent).toContain('Tell me what you want to improve');
+    expect(container.textContent).toContain(
+      'Share the challenge, process or idea you want to move forward. I will reply personally to understand the context and see whether it makes sense to work together.'
+    );
+    expect(container.textContent).toContain('Direct route');
+    expect(container.textContent).toContain('Message me on WhatsApp');
+    expect(container.textContent).toContain('Best for a quick first conversation.');
+    expect(container.textContent).toContain('Or send me some context');
+    expect(container.textContent).toContain('No automatic diagnosis or mandatory scheduling. We start with the challenge.');
+    expect(container.textContent).toContain('You can also find me on');
+    expect(container.textContent).toContain('Monterrey, Mexico · Remote work');
+
+    cleanup();
+  });
+
+  it('keeps the published WhatsApp link', () => {
+    const { container, cleanup } = renderContacto('es');
+    const whatsapp = Array.from(container.querySelectorAll('a')).find((link) =>
+      link.textContent.includes('Escríbeme por WhatsApp')
+    );
+
+    expect(whatsapp).toBeTruthy();
+    expect(whatsapp.getAttribute('href')).toBe(WHATSAPP_URL);
+    expect(whatsapp.getAttribute('target')).toBe('_blank');
+    expect(whatsapp.getAttribute('rel')).toBe('noopener noreferrer');
+
+    cleanup();
+  });
+
+  it('uses accessible labels and expected required fields', () => {
+    const { container, cleanup } = renderContacto('es');
+    const name = getFieldByLabel(container, 'Tu nombre');
+    const mail = getFieldByLabel(container, 'Tu correo');
+    const message = getFieldByLabel(container, '¿Qué quieres mejorar, automatizar, simplificar, digitalizar o crear?');
+
+    expect(name.getAttribute('id')).toBe('contact-name');
+    expect(name.getAttribute('name')).toBe('name');
+    expect(name.required).toBe(true);
+    expect(name.getAttribute('autocomplete')).toBe('name');
+    expect(mail.getAttribute('id')).toBe('contact-mail');
+    expect(mail.getAttribute('name')).toBe('mail');
+    expect(mail.required).toBe(true);
+    expect(mail.type).toBe('email');
+    expect(mail.getAttribute('autocomplete')).toBe('email');
+    expect(message.getAttribute('id')).toBe('contact-message');
+    expect(message.getAttribute('name')).toBe('message');
+    expect(message.required).toBe(true);
+    expect(message.getAttribute('autocomplete')).toBe('off');
+
+    cleanup();
+  });
+
+  it('submits the exact current endpoint payload on success', async () => {
+    global.fetch.mockResolvedValue({ ok: true });
+    const { container, cleanup } = renderContacto('es');
+
+    setFieldValue(getFieldByLabel(container, 'Tu nombre'), 'Ana');
+    setFieldValue(getFieldByLabel(container, 'Tu correo'), 'ana@example.com');
+    setFieldValue(
+      getFieldByLabel(container, '¿Qué quieres mejorar, automatizar, simplificar, digitalizar o crear?'),
+      'Quiero simplificar un proceso interno.'
+    );
+
+    submitForm(container);
+    await act(async () => {});
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(CONTACT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Ana',
+        mail: 'ana@example.com',
+        message: 'Quiero simplificar un proceso interno.'
+      })
+    });
+
+    cleanup();
+  });
+
+  it('disables the submit button while sending and prevents double submit', () => {
+    const pending = createDeferred();
+    global.fetch.mockReturnValue(pending.promise);
+    const { container, cleanup } = renderContacto('es');
+
+    setFieldValue(getFieldByLabel(container, 'Tu nombre'), 'Ana');
+    setFieldValue(getFieldByLabel(container, 'Tu correo'), 'ana@example.com');
+    setFieldValue(
+      getFieldByLabel(container, '¿Qué quieres mejorar, automatizar, simplificar, digitalizar o crear?'),
+      'Necesito automatizar seguimiento.'
+    );
+
+    submitForm(container);
+    const button = container.querySelector('button[type="submit"]');
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toContain('Enviando mensaje…');
+
+    submitForm(container);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      pending.resolve({ ok: true });
+    });
+
+    cleanup();
+  });
+
+  it('shows the approved success message', async () => {
+    global.fetch.mockResolvedValue({ ok: true });
+    const { container, cleanup } = renderContacto('es');
+
+    setFieldValue(getFieldByLabel(container, 'Tu nombre'), 'Ana');
+    setFieldValue(getFieldByLabel(container, 'Tu correo'), 'ana@example.com');
+    setFieldValue(
+      getFieldByLabel(container, '¿Qué quieres mejorar, automatizar, simplificar, digitalizar o crear?'),
+      'Quiero crear una herramienta.'
+    );
+
+    submitForm(container);
+    await act(async () => {});
+
+    expect(container.querySelector('[aria-live="polite"]').textContent).toContain(
+      'Gracias, ya recibí tu mensaje. Te responderé personalmente.'
+    );
+
+    cleanup();
+  });
+
+  it('shows WhatsApp and email fallbacks for HTTP errors and network errors', async () => {
+    const cases = [
+      () => Promise.resolve({ ok: false }),
+      () => Promise.reject(new Error('network'))
+    ];
+
+    for (const createResponse of cases) {
+      global.fetch.mockReset();
+      global.fetch.mockImplementation(createResponse);
+      const { container, cleanup } = renderContacto('es');
+
+      setFieldValue(getFieldByLabel(container, 'Tu nombre'), 'Ana');
+      setFieldValue(getFieldByLabel(container, 'Tu correo'), 'ana@example.com');
+      setFieldValue(
+        getFieldByLabel(container, '¿Qué quieres mejorar, automatizar, simplificar, digitalizar o crear?'),
+        'Quiero digitalizar atención.'
+      );
+
+      submitForm(container);
+      await act(async () => {});
+
+      expect(container.querySelector('[aria-live="polite"]').textContent).toContain(
+        'No pude enviar tu mensaje en este momento. Puedes escribirme por WhatsApp o correo.'
+      );
+      expect(container.querySelector(`a[href="${WHATSAPP_URL}"]`)).toBeTruthy();
+      expect(container.querySelector(`a[href="mailto:${EMAIL}"]`)).toBeTruthy();
+
+      cleanup();
+    }
+  });
+
+  it('does not render removed legacy routes, assets or scheduling copy', () => {
+    const { container, cleanup } = renderContacto('en');
+    const html = container.innerHTML;
+
+    expect(container.textContent).not.toContain('Diagnóstico');
+    expect(container.textContent).not.toContain('Calendly');
+    expect(container.textContent).not.toContain('Cal.com');
+    expect(container.textContent).not.toContain('View resume');
+    expect(container.textContent).not.toContain('Ver CV');
+    expect(container.textContent).not.toContain('Google Maps');
+    expect(html).not.toContain('calendly');
+    expect(html).not.toContain('google.com/maps');
+    expect(html).not.toContain('.pdf');
+    expect(html).not.toContain('diagnosis/');
+
+    cleanup();
+  });
+
+  it('keeps the quote subject prefill', () => {
+    const { container, cleanup } = renderContacto('en', '/contacto?subject=quote');
+    const message = getFieldByLabel(container, 'What do you want to improve, automate, simplify, digitize or create?');
+
+    expect(message.value).toBe('Hi, I would like to request a quote.');
 
     cleanup();
   });

--- a/my-app/src/styles/components/Contacto.css
+++ b/my-app/src/styles/components/Contacto.css
@@ -1,305 +1,380 @@
-/* Variables de color */
-@import '../index.css'; 
-  
-/* Estilos para la sección de Contacto en modo oscuro */
+@import '../index.css';
+
 .contacto {
-    position: relative;
-    padding: 60px 20px;
-    background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg-3)), var(--section-bg-end, var(--color-bg)));
-    margin-left: auto;
-    margin-right: auto;
-    min-height: 100vh;
-    overflow: hidden;
+  position: relative;
+  width: 100%;
+  padding: 80px 20px;
+  background:
+    linear-gradient(180deg, rgba(var(--hero-title-color-rgb, 125, 211, 252), 0.08), transparent 34%),
+    var(--color-bg);
+  color: var(--color-text);
+  overflow-x: hidden;
 }
 
-
-/* Añadido para centrar la imagen y el título en una sola línea */
-.contacto-header {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 20px;
+.contacto *,
+.contacto *::before,
+.contacto *::after {
+  box-sizing: border-box;
 }
 
-/* Estilo para la imagen del perfil */
-.contacto-imagen {
-    width: 150px; 
-    height: 150px;
-    border-radius: 50%; 
-    margin-right: 20px; 
-    transition: transform 1s ease;
+.contacto-shell {
+  width: min(1120px, 100%);
+  margin: 0 auto;
 }
 
-/* Estilo para la imagen del perfil */
-.contacto-imagen:hover {
-    transform: scale(1.1);
-  }
-
-/* Estilo para el contenedor del título */
-.contacto-titulo {
-    text-align: left;
+.contacto-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(280px, 1.05fr);
+  gap: 28px;
+  align-items: end;
+  margin-bottom: 28px;
 }
 
-/* Estilo para el título */
-.contacto-titulo h2 {
-    margin: 0;
-    color: var(--color-text);
-    font-size: 2rem;
+.contacto-eyebrow,
+.contacto-route-label {
+  margin: 0 0 10px;
+  color: var(--color-accent);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
-/* Estilo para la frase en cursiva */
-.contacto-frase {
-    font-style: italic;
-    color: var(--color-text);
-    margin-top: 10px;
-    transition: transform 1s ease;
-
-}
-
-.contacto-frase:hover {
-    transform: scale(1.1);
-}
-
-
-/* Estilos del título de la sección */
 .contacto h2 {
-    margin: 20px 0; /* Espaciado fijo alrededor del título */
-    text-align: center;
-    font-size: 3rem; /* Ajusta el tamaño del texto según necesites */
-    color: var(--hero-title-color-2);
-    position: sticky; /* Fija el título en la parte superior */
-    top: 0;
-    background-color: transparent; /* Fondo para mantener la legibilidad */
-    z-index: 100;
-    text-transform: uppercase;
-  }
-
-/* Contenido del contacto */
-.contacto-contenido {
-    display: flex;
-    flex-direction: row;
-    gap: 20px;
-    align-items: flex-start;
-    justify-content: flex-start; /* Ajuste de distribución */
-    margin: 0 auto;
-    max-width: 1000px; /* Ajusta el ancho máximo según sea necesario */
+  margin: 0;
+  color: var(--hero-title-color-2);
+  font-size: clamp(2rem, 4vw, 3.35rem);
+  line-height: 1.05;
+  overflow-wrap: anywhere;
+  text-align: left;
+  text-transform: none;
 }
 
-/* Estilos del formulario de contacto */
+.contacto-heading > p {
+  max-width: 640px;
+  margin: 0;
+  color: var(--color-text);
+  font-size: 1.05rem;
+  line-height: 1.75;
+  opacity: 0.88;
+}
+
+.contacto-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.85fr) minmax(360px, 1.15fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.contacto-conversation,
 .formulario-contacto {
-    flex: 2;
-    width: 100%; /* Ocupará todo el ancho disponible */
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-solid);
+  box-shadow: 0 16px 36px rgba(2, 8, 23, 0.12);
 }
 
-
-/* Campos de entrada */
-.formulario-contacto input,
-.formulario-contacto textarea {
-    width: 100%;
-    padding: 10px;
-    margin-bottom: 10px; /* Reducido el margen inferior entre campos */
-    border: 1px solid var(--color-border);
-    border-radius: 5px;
-    background-color: var(--color-bg-3) !important; /* Fondo oscuro para los campos */
-    color: var(--color-texto);
+.contacto-conversation {
+  display: grid;
+  gap: 18px;
+  padding: 22px;
 }
 
-/* Estilos para los botones CTA */
-.formulario-contacto button {
-    background: linear-gradient(135deg, #a80c9b, #7bcff8, #00cc99);
-    background-size: 300% 300%;
-    animation: gradientBG 10s ease infinite;
-    margin-left: 10px;
-    color: white;
-    padding: 10px 20px;
-    font-size: 1rem;
-    border: none;
-    border-radius: 20px;
-    cursor: pointer;
-    transition: transform 0.3s ease, color 0.3s ease;
-    text-decoration: none;
-    font-weight: bold;
+.contacto-profile {
+  display: grid;
+  grid-template-columns: 86px minmax(0, 1fr);
+  gap: 18px;
+  align-items: center;
+}
+
+.contacto-imagen {
+  width: 86px;
+  height: 86px;
+  border: 2px solid var(--color-accent);
+  border-radius: 50%;
+  object-fit: cover;
+  object-position: center;
+  box-shadow: 0 10px 24px rgba(2, 8, 23, 0.16);
+}
+
+.contacto-whatsapp,
+.contacto-submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+  transition:
+    background-color 180ms ease,
+    border-color 180ms ease,
+    color 180ms ease,
+    box-shadow 180ms ease,
+    transform 180ms ease,
+    opacity 180ms ease;
+}
+
+.contacto-whatsapp {
+  width: 100%;
+  gap: 10px;
+  padding: 12px 16px;
+  background: var(--color-accent);
+  color: var(--color-bg-solid);
+}
+
+.contacto-whatsapp:hover,
+.contacto-submit:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px rgba(0, 204, 153, 0.22);
+}
+
+.contacto-whatsapp:focus-visible,
+.contacto-submit:focus-visible,
+.contacto a:focus-visible,
+.contacto input:focus-visible,
+.contacto textarea:focus-visible {
+  outline: 3px solid rgba(var(--hero-title-color-rgb, 125, 211, 252), 0.55);
+  outline-offset: 3px;
+}
+
+.contacto-helper {
+  margin: 10px 0 0;
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.contacto-secondary {
+  padding-top: 18px;
+  border-top: 1px solid var(--color-border);
+}
+
+.contacto-secondary h3,
+.contacto-form-heading h3 {
+  margin: 0 0 14px;
+  color: var(--color-text);
+  font-size: 1.2rem;
+  line-height: 1.25;
+}
+
+.contacto-secondary ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.contacto-secondary a,
+.contacto-location,
+.contacto-feedback-links a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.contacto-secondary a,
+.contacto-location {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  min-height: 40px;
+  padding: 8px 0;
+  overflow-wrap: anywhere;
+  transition:
+    color 180ms ease,
+    transform 180ms ease;
+}
+
+.contacto-secondary a:hover {
+  color: var(--color-accent);
+  transform: translateX(4px);
+}
+
+.contacto-secondary i,
+.contacto-location i {
+  width: 20px;
+  color: var(--color-accent);
+  text-align: center;
+}
+
+.formulario-contacto {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+}
+
+.contacto-form-heading p {
+  margin: 0;
+  color: var(--color-secondary);
+  line-height: 1.6;
+}
+
+.contacto-field {
+  display: grid;
+  gap: 8px;
+}
+
+.contacto-field label {
+  color: var(--color-text);
+  font-size: 0.95rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.contacto-field input,
+.contacto-field textarea {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-solid);
+  color: var(--color-text);
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1.5;
+  transition:
+    border-color 180ms ease,
+    box-shadow 180ms ease,
+    background-color 180ms ease;
+}
+
+.contacto-field input {
+  min-height: 48px;
+  padding: 0 14px;
+}
+
+.contacto-field textarea {
+  min-height: 144px;
+  padding: 12px 14px;
+  resize: vertical;
+}
+
+.contacto-field input:focus,
+.contacto-field textarea:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(var(--hero-title-color-rgb, 125, 211, 252), 0.18);
+}
+
+.contacto-submit {
+  width: fit-content;
+  min-width: 164px;
+  padding: 12px 20px;
+  background: var(--hero-title-color-2);
+  color: var(--color-bg-solid);
+  cursor: pointer;
+}
+
+.contacto-submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.contacto-feedback {
+  min-height: 28px;
+  color: var(--color-text);
+  line-height: 1.55;
+}
+
+.contacto-feedback p {
+  margin: 0;
+}
+
+.contacto-feedback--success {
+  color: #16a34a;
+}
+
+.contacto-feedback--error {
+  color: #dc2626;
+}
+
+.contacto-feedback-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.contacto-feedback-links a {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+
+[data-theme="dark"] .contacto-conversation,
+[data-theme="dark"] .formulario-contacto {
+  background: var(--color-bg-solid);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.26);
+}
+
+[data-theme="dark"] .contacto-whatsapp,
+[data-theme="dark"] .contacto-submit {
+  color: #020817;
+}
+
+[data-theme="dark"] .contacto-feedback--success {
+  color: #86efac;
+}
+
+[data-theme="dark"] .contacto-feedback--error {
+  color: #fca5a5;
+}
+
+@media (max-width: 820px) {
+  .contacto {
+    padding: 64px 18px;
   }
-  
-.formulario-contacto button:hover {
-background-color: var(--hero-button-hover-bg-color);
-transform: translateY(-2px);
-box-shadow: 0 6px 8px rgba(0,0,0,0.3);
-text-shadow: 0 2px 4px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2);
-animation: gradientBG 18s ease infinite;
+
+  .contacto-heading,
+  .contacto-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .contacto-heading {
+    gap: 14px;
+  }
 }
 
-.formulario-contacto button:active {
-transform: scale(0.95) !important;
-box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3), inset 0 -1px 2px rgba(0, 0, 0, 0.2);
-animation: none;
-}
+@media (max-width: 480px) {
+  .contacto {
+    padding: 56px 14px;
+  }
 
+  .contacto-conversation,
+  .formulario-contacto {
+    padding: 18px;
+  }
 
+  .contacto-profile {
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 14px;
+  }
 
-/* Placeholder animación */
-.input-container {
-    position: relative;
-    border-radius: 5px;
-    padding: 10px 10px;
-}
+  .contacto-imagen {
+    width: 72px;
+    height: 72px;
+  }
 
-.input-placeholder {
-    position: absolute;
-    left: 10px;
-    top: 30%;
-    color: var(--color-text);
-    background-color: var(--color-bg-3);
-    pointer-events: none;
-    transition: transform 0.2s ease, font-size 0.2s ease;
-}
+  .contacto-helper {
+    margin-top: 6px;
+  }
 
-/* Animación especial para el campo Mensaje */
-.input-container.special .input-placeholder {
-    transform: translateY(-60px); /* Desplazamiento pronunciado para el campo Mensaje */
-}
+  .contacto-secondary {
+    padding-top: 14px;
+  }
 
+  .contacto-secondary ul {
+    gap: 2px;
+  }
 
-.input-field {
+  .contacto-secondary a,
+  .contacto-location {
+    min-height: 34px;
+    padding: 4px 0;
+  }
+
+  .contacto-whatsapp,
+  .contacto-submit {
     width: 100%;
-    font-size: 18px;
-    padding: 5px 0;
-    border: none;
-    outline: none;
-}
-
-.input-field.textarea-field {
-    width: 100%;
-    height: 150px; /* Ajusta la altura según sea necesario */
-    padding: 12px;
-    border: 1px solid var(--color-border);
-    border-radius: 5px;
-    background-color: var(--color-accent);
-    color: var(--color-text);
-    resize: vertical; /* Permite redimensionar verticalmente */
-    overflow-y: auto; /* Habilita el scroll interno */
-    white-space: pre-wrap; /* Mantiene los saltos de línea */
-    word-wrap: break-word; /* Rompe las palabras largas para evitar el desbordamiento */
-}
-
-.textarea-field {
-    height: 150px !important; /* Ajusta la altura del textarea para ser más grande */
-    resize: vertical !important; /* Permite redimensionar verticalmente */
-    overflow-y: auto !important; /* Habilita el scroll interno */
-}
-
-
-/* Títulos para las categorías */
-.info-contacto h3,
-.redes-sociales h3,
-.agenda-documentos h3 {
-    font-size: 20px; 
-    font-weight: 700; 
-    color: var(--hero-title-color-2);
-    margin-top: 10px; /* Más espacio debajo del título */
-    border-bottom: 2px solid var(--color-primary); /* Línea fina y elegante debajo */
-    padding-bottom: 2px; /* Espaciado entre título y línea */
-}
-
-/* Información de contacto */
-.info-contacto {
-    flex: 1;
-    margin-left: 10px;
-    width: 100%; /* Para móviles, se apilará debajo del formulario */}
-
-.info-contacto p {
-    color: var(--color-text);
-}
-
-
-.info-contacto-links,
-.redes-sociales-links,
-.agenda-documentos-links {
-    display: flex;
-    flex-direction: column;
-    padding-top: 5px; 
-}
-
-.info-contacto-link,
-.redes-sociales-link,
-.agenda-documentos-link {
-    display: flex;
-    align-items: center;
-    color: var(--color-primary);
-    text-decoration: none;
-    font-size: 16px;
-    font-weight: 500;
-    transition: color 0.3s ease, transform 0.3s ease;
-    padding: 5px 0; 
-    margin-bottom: 5px;
-    margin-left: 10px; 
-}
-.info-contacto-link svg ,
-.redes-sociales-link svg ,
-.agenda-documentos-link svg {
-    display: inline-block; /* Asegura que el ícono respete márgenes */
-    margin-right: 10px !important; /* Forzar el margen */
-    font-size: 20px;
-}
-.info-contacto-link:hover,
-.redes-sociales-link:hover,
-.agenda-documentos-link:hover {
-    color: var(--color-accent);
-    transform: translateX(10px); /* Desplazamiento más elegante a la derecha */
-    text-shadow: 0 2px 5px rgba(0, 0, 0, 0.1); /* Sombra sutil al hover */
-    
-}
-
-.info-contacto-link:active,
-.redes-sociales-link:active,
-.agenda-documentos-link:active {
-    transform: scale(0.95); /* Desplazamiento más elegante a la derecha */
-}
-
-
-
-/* Estilo para el mensaje de éxito y error */
-.buttonmessage {
-    margin-left: 20px;
-}
-  
-
-/* Estilos responsivos para móviles */
-@media (max-width: 768px) {
-    /* En pantallas pequeñas, los elementos se colocan uno debajo del otro */
-    .contacto-header {
-        flex-direction: column; /* Apila los elementos verticalmente */
-        align-items: center; /* Alinea los elementos en el centro */
-    }
-    
-    .contacto-contenido {
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        gap: 30px; /* Espaciado entre bloques */
-    }
-
-    /* Asegura que el formulario y la info ocupen el ancho completo */
-    .formulario-contacto,
-    .info-contacto {
-        max-width: 100%;
-    }
-
-   /* Opcional: ajusta el tamaño de la imagen en móvil */
-   .contacto-imagen {
-        order: 2; /* Coloca la imagen después del título */
-        width: 100px; /* Tamaño más pequeño para pantallas móviles */
-        height: 100px;
-        margin: 20px 0; /* Espaciado alrededor de la imagen */
-    }
-
-    .contacto-titulo h2 {
-        text-align: center;
-        margin-bottom: 10px;
-        font-size: 1.8rem;
-    }
-
-    .contacto-frase {
-        text-align: center;
-    }
+  }
 }


### PR DESCRIPTION
## Summary
- Redesigns `Contacto` as a two-route conversation start: WhatsApp for quick contact and a contextual form.
- Preserves `id="contacto"`, `scrollMarginTop: 96px`, the existing Buildship endpoint, and the exact `{ name, mail, message }` payload.
- Keeps the current profile image with a circular mask, plus existing email, LinkedIn, GitHub and WhatsApp details.
- Removes Contacto exposure of CV, Google Maps and old generic/contact copy.

## UX and accessibility
- Adds real labels tied to `id`/`name` controls, required fields, `type="email"`, autocomplete attributes, `isSubmitting`, disabled submit state and `aria-live="polite"` feedback.
- Keeps `/contacto?subject=quote` prefill behavior.
- Adds error fallback links for WhatsApp and email without sending QA data to the endpoint.

## Validation
- `npm test -- --runInBand src/components/Contacto.test.js --watchAll=false` passed: 10/10.
- `npm run build` passed.
- `git diff --check` passed.
- `git restore my-app/src/config/hashedPasscodes.js` run after build.

## Manual QA
- Browser/IAB QA on `http://localhost:3000/#contacto`.
- Checked 1440x900, 1280x800, 390x844 and 375x812.
- Checked Spanish/English and dark/light themes.
- Verified WhatsApp href, required fields, no horizontal overflow, empty form blocked by native validation, and no relevant console errors.

## Notes
- Existing unrelated local change in `my-app/src/data/clientProjects.json` was not staged or included.
- Browser `domSnapshot()` API failed in this environment, so rendered QA used Browser screenshots, read-only DOM evaluation, console logs and interaction checks.