### PR TITLE
[codex] Unify section visual system

### DIFF
--- a/my-app/src/components/HeroBanner.js
+++ b/my-app/src/components/HeroBanner.js
@@ -16,7 +16,7 @@ const DynamicHeroBanner = ({ style }) => {
       {
         title: 'Transformo procesos complicados en soluciones que realmente funcionan.',
         subtitle: 'Ex-COO de GoFarma y Digital Product Owner en CHUBB.',
-        description: 'Estrategia, prototipo y métricas reales para validar, automatizar o destrabar un reto operativo sin humo.',
+        description: 'Estrategia, prototipo y métricas reales para validar, automatizar o destrabar un reto operativo con claridad y ejecución visible.',
         icon: '🧪',
         cta: 'Hablemos de tu reto',
         secondaryCta: 'Ver casos reales'
@@ -26,7 +26,7 @@ const DynamicHeroBanner = ({ style }) => {
       {
         title: 'I turn your business idea into a working digital product in weeks, not months',
         subtitle: 'Ex-COO at GoFarma and Digital Product Owner at CHUBB.',
-        description: 'Strategy, prototype and real metrics to validate, automate or unblock an operational challenge without fluff.',
+        description: 'Strategy, prototype and real metrics to validate, automate or unblock an operational challenge with clarity and visible execution.',
         icon: '🧪',
         cta: 'Let’s talk about your challenge',
         secondaryCta: 'See real cases'
@@ -123,7 +123,9 @@ const DynamicHeroBanner = ({ style }) => {
         </figure>
 
         <div className="info-container">
-          <span className="hero-eyebrow">Producto digital · Operaciones · IA aplicada</span>
+          <span className="hero-eyebrow">
+            {language === 'es' ? 'Producto digital · Operaciones · IA aplicada' : 'Digital product · Operations · Applied AI'}
+          </span>
           <h2 className="hero-title shiny">{currentContent?.title}</h2>
           <h3 className="hero-subtitle">{currentContent?.subtitle}</h3>
           <p className="hero-description">{currentContent?.description}</p>

--- a/my-app/src/components/HeroBanner.test.js
+++ b/my-app/src/components/HeroBanner.test.js
@@ -57,6 +57,8 @@ describe('HeroBanner', () => {
     const { container, cleanup } = renderHero('es');
 
     expect(container.textContent).toContain('Transformo procesos complicados en soluciones que realmente funcionan.');
+    expect(container.textContent).toContain('con claridad y ejecución visible');
+    expect(container.textContent).not.toContain('sin humo');
     expect(container.textContent).not.toContain('Solo tomo proyectos con foco');
     expect(container.textContent).not.toContain('producto digital funcional en semanas, no meses');
 
@@ -95,6 +97,8 @@ describe('HeroBanner', () => {
     const { container, cleanup } = renderHero('en');
 
     expect(container.textContent).toContain('I turn your business idea into a working digital product in weeks, not months');
+    expect(container.textContent).toContain('with clarity and visible execution');
+    expect(container.textContent).not.toContain('without fluff');
     expect(container.querySelector('.hero-button').textContent).toContain('Let’s talk about your challenge');
     expect(container.querySelector('.scroll-indicator').textContent).toContain('See solutions');
     expect(container.innerHTML).not.toContain('calendly.com');

--- a/my-app/src/components/Servicios.js
+++ b/my-app/src/components/Servicios.js
@@ -59,24 +59,28 @@ function Servicios({ style }) {
   const t = content[language] || content.es;
 
   return (
-    <section id="como-trabajo" className="servicios colaboraciones disponibilidad" style={{ scrollMarginTop: '96px', ...style }}>
-      <div className="servicios-header">
-        <h1>{t.heading}</h1>
-      </div>
-      <p className="introduccion shinyh">{t.intro}</p>
-      <div className="servicios-grid simple-grid">
+    <section id="como-trabajo" className="servicios" style={{ scrollMarginTop: '96px', ...style }}>
+      <div className="servicios-shell">
+        <div className="servicios-header">
+          <span>{language === 'es' ? 'Método de colaboración' : 'Collaboration method'}</span>
+          <h2>{t.heading}</h2>
+          <p>{t.intro}</p>
+        </div>
+      <div className="servicios-grid">
         {t.blocks.map((block, idx) => (
-          <div key={idx} className="servicio-card minimal">
+          <article key={idx} className="servicio-card">
+            <div className="servicio-card__index">{String(idx + 1).padStart(2, '0')}</div>
             <h3>{block.title}</h3>
             <ul className="bullet-clean">
               {block.items.map((it, i) => (<li key={i}>{it}</li>))}
             </ul>
-          </div>
+          </article>
         ))}
       </div>
       <div className="servicio-cta global-cta">
         <button className="cta-button-3" onClick={() => document.getElementById('contacto')?.scrollIntoView({ behavior: 'smooth' })}>{t.cta}</button>
         <div className="cta-helper-text">{t.ctaHelper}</div>
+      </div>
       </div>
     </section>
   );

--- a/my-app/src/styles/components/CasosEstudio.css
+++ b/my-app/src/styles/components/CasosEstudio.css
@@ -1,13 +1,13 @@
 .casos-estudio {
-  padding: 78px 20px;
+  padding: 86px 20px;
   scroll-margin-top: 78px;
   color: var(--color-text);
-  background: var(--color-bg);
+  background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg)), var(--section-bg-end, var(--color-bg-3)));
 }
 
 .casos-estudio__header {
   max-width: 760px;
-  margin: 0 auto 32px;
+  margin: 0 auto 38px;
   text-align: center;
 }
 
@@ -38,28 +38,44 @@
 .casos-estudio__grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 24px;
+  gap: 22px;
   max-width: 1120px;
   margin: 0 auto;
 }
 
 .caso-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 14px;
   padding: 18px;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  background: linear-gradient(180deg, var(--color-bg-solid), var(--color-bg));
-  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.18);
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card);
+  background: var(--color-bg-solid);
+  box-shadow: var(--ui-card-shadow);
   min-width: 0;
+  overflow: hidden;
+  animation: caseCardIn 520ms ease both;
+  transition:
+    border-color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    transform var(--ui-transition);
+}
+
+.caso-card:nth-child(2) { animation-delay: 100ms; }
+
+.caso-card:hover,
+.caso-card:focus-within {
+  border-color: var(--color-accent);
+  box-shadow: var(--ui-card-shadow-hover);
+  transform: translateY(-4px);
 }
 
 .caso-card__preview {
   aspect-ratio: 16 / 9;
   overflow: hidden;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card-sm);
   background: var(--color-bg);
 }
 
@@ -68,6 +84,11 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  transition: transform var(--ui-transition);
+}
+
+.caso-card:hover .caso-card__preview img {
+  transform: scale(1.025);
 }
 
 .caso-card__category {
@@ -111,8 +132,8 @@
 
 .caso-card__blocks p {
   padding: 12px 14px;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card-sm);
   background: rgba(255, 255, 255, 0.03);
   font-size: 0.95rem;
 }
@@ -126,7 +147,7 @@
 }
 
 .caso-card__result {
-  border-color: var(--color-border);
+  border-color: var(--ui-card-border);
   border-left: 4px solid var(--color-accent);
   background: var(--color-bg);
   font-weight: 700;
@@ -155,16 +176,74 @@
   text-decoration: underline;
 }
 
+.caso-card__link:focus-visible {
+  outline: 3px solid var(--ui-focus-ring);
+  outline-offset: 3px;
+}
+
 .casos-estudio__cta {
   display: block;
   margin: 32px auto 0;
   padding: 14px 32px;
-  border: none;
-  border-radius: 999px;
-  color: #ffffff;
-  background: #a80c9b;
+  border: 1px solid transparent;
+  border-radius: var(--ui-radius-pill);
+  color: var(--color-bg-solid);
+  background: var(--hero-title-color-2);
+  font: inherit;
   font-weight: 800;
   cursor: pointer;
+  transition:
+    background-color var(--ui-transition),
+    border-color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    color var(--ui-transition),
+    opacity var(--ui-transition),
+    transform var(--ui-transition);
+}
+
+.casos-estudio__cta:hover,
+.casos-estudio__cta:focus {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  box-shadow: 0 12px 24px rgba(0, 204, 153, 0.2);
+  transform: translateY(-2px);
+}
+
+.casos-estudio__cta:focus-visible {
+  outline: 3px solid var(--ui-focus-ring);
+  outline-offset: 3px;
+}
+
+.casos-estudio__cta:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+@keyframes caseCardIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .caso-card,
+  .caso-card__preview img {
+    animation: none;
+    transition: none;
+  }
+
+  .caso-card:hover,
+  .caso-card:focus-within,
+  .caso-card:hover .caso-card__preview img,
+  .casos-estudio__cta:hover,
+  .casos-estudio__cta:focus {
+    transform: none;
+  }
 }
 
 @media (max-width: 900px) {
@@ -176,12 +255,13 @@
 
 @media (max-width: 520px) {
   .casos-estudio {
-    padding: 38px 14px 46px;
+    padding: 54px 14px;
     scroll-margin-top: 44px;
   }
 
   .casos-estudio__header {
     margin-bottom: 18px;
+    text-align: left;
   }
 
   .casos-estudio__header span {

--- a/my-app/src/styles/components/Contacto.css
+++ b/my-app/src/styles/components/Contacto.css
@@ -3,7 +3,7 @@
 .contacto {
   position: relative;
   width: 100%;
-  padding: 80px 20px;
+  padding: 86px 20px;
   background:
     linear-gradient(180deg, rgba(var(--hero-title-color-rgb, 125, 211, 252), 0.08), transparent 34%),
     var(--color-bg);
@@ -68,10 +68,21 @@
 
 .contacto-conversation,
 .formulario-contacto {
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card);
   background: var(--color-bg-solid);
-  box-shadow: 0 16px 36px rgba(2, 8, 23, 0.12);
+  box-shadow: var(--ui-card-shadow);
+  transition:
+    border-color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    transform var(--ui-transition);
+}
+
+.contacto-conversation:hover,
+.formulario-contacto:focus-within {
+  border-color: var(--color-accent);
+  box-shadow: var(--ui-card-shadow-hover);
+  transform: translateY(-3px);
 }
 
 .contacto-conversation {
@@ -103,18 +114,18 @@
   align-items: center;
   justify-content: center;
   min-height: 48px;
-  border-radius: 8px;
+  border-radius: var(--ui-radius-pill);
   border: 1px solid transparent;
   font: inherit;
   font-weight: 700;
   text-decoration: none;
   transition:
-    background-color 180ms ease,
-    border-color 180ms ease,
-    color 180ms ease,
-    box-shadow 180ms ease,
-    transform 180ms ease,
-    opacity 180ms ease;
+    background-color var(--ui-transition),
+    border-color var(--ui-transition),
+    color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    transform var(--ui-transition),
+    opacity var(--ui-transition);
 }
 
 .contacto-whatsapp {
@@ -227,8 +238,8 @@
 .contacto-field input,
 .contacto-field textarea {
   width: 100%;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card-sm);
   background: var(--color-bg-solid);
   color: var(--color-text);
   font: inherit;
@@ -304,7 +315,25 @@
 [data-theme="dark"] .contacto-conversation,
 [data-theme="dark"] .formulario-contacto {
   background: var(--color-bg-solid);
-  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.26);
+  box-shadow: var(--ui-card-shadow);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .contacto-conversation,
+  .formulario-contacto,
+  .contacto-whatsapp,
+  .contacto-submit,
+  .contacto-secondary a {
+    transition: none;
+  }
+
+  .contacto-conversation:hover,
+  .formulario-contacto:focus-within,
+  .contacto-whatsapp:hover,
+  .contacto-submit:hover:not(:disabled),
+  .contacto-secondary a:hover {
+    transform: none;
+  }
 }
 
 [data-theme="dark"] .contacto-whatsapp,

--- a/my-app/src/styles/components/HeroBanner.css
+++ b/my-app/src/styles/components/HeroBanner.css
@@ -12,7 +12,7 @@ html { scroll-behavior: smooth; }
   background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg)), var(--section-bg-end, var(--color-bg-3)));
   overflow-x: hidden;
   color: var(--color-text);
-  padding: 90px 20px 70px;
+  padding: 92px 20px 72px;
   box-sizing: border-box;
 }
 
@@ -33,7 +33,7 @@ html { scroll-behavior: smooth; }
   display: grid;
   grid-template-columns: 0.8fr 1.2fr;
   align-items: center;
-  gap: 32px;
+  gap: 38px;
   width: min(1120px, 100%);
   max-width: 100%;
 }
@@ -66,7 +66,7 @@ html { scroll-behavior: smooth; }
   max-width: 100%;
   font-size: clamp(2.1rem, 5.2vw, 4.55rem);
   line-height: 1.04;
-  font-weight: bold;
+  font-weight: 800;
   color: var(--color-text);
   margin: 0 0 1rem;
   overflow-wrap: anywhere;
@@ -104,36 +104,68 @@ html { scroll-behavior: smooth; }
   max-width: 100%;
   padding: 12px 22px;
   font-size: 1rem;
-  border-radius: 999px;
+  border-radius: var(--ui-radius-pill);
   cursor: pointer;
-  font-weight: bold;
+  font-weight: 800;
   white-space: normal;
+  transition:
+    background-color var(--ui-transition),
+    border-color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    color var(--ui-transition),
+    opacity var(--ui-transition),
+    transform var(--ui-transition);
 }
 
 .hero-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #a80c9b, #7bcff8, #00cc99);
-  background-size: 300% 300%;
-  animation: gradientBG 10s ease infinite;
-  color: #ffffff;
-  border: none;
+  background: var(--hero-title-color-2);
+  color: var(--color-bg-solid);
+  border: 1px solid transparent;
   text-decoration: none;
 }
 
 .hero-button-secondary {
-  background: transparent;
+  background: var(--color-bg-solid);
   color: var(--color-text);
-  border: 1px solid var(--color-border);
+  border: 1px solid var(--ui-card-border);
+}
+
+.hero-button:hover,
+.hero-button:focus-visible,
+.hero-button-secondary:hover,
+.hero-button-secondary:focus-visible {
+  border-color: var(--color-accent);
+  box-shadow: 0 12px 24px rgba(0, 204, 153, 0.2);
+  transform: translateY(-2px);
+}
+
+.hero-button:hover,
+.hero-button:focus-visible {
+  background: var(--color-accent);
+}
+
+.hero-button-secondary:hover,
+.hero-button-secondary:focus-visible {
+  color: var(--color-accent);
+}
+
+.hero-button:focus-visible,
+.hero-button-secondary:focus-visible,
+.scroll-indicator:focus-visible {
+  outline: 3px solid var(--ui-focus-ring);
+  outline-offset: 3px;
 }
 
 .hero-portrait-card {
   margin: 0;
   padding: 12px;
-  border: 1px solid var(--color-border);
-  border-radius: 24px;
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card);
   background: var(--color-bg-solid);
+  box-shadow: var(--ui-card-shadow);
   width: min(320px, 100%);
   justify-self: center;
   box-sizing: border-box;
@@ -195,15 +227,34 @@ html { scroll-behavior: smooth; }
 .fade-out { opacity: 0; transition: opacity 0.5s ease-out; pointer-events: none; }
 
 .shiny {
-  background: linear-gradient(to right, var(--color-accent) 0%, var(--hero-title-color) 50%, var(--color-accent) 100%);
-  background-size: 200% auto;
+  background: linear-gradient(to right, var(--hero-title-color-2) 0%, var(--hero-title-color) 58%, var(--color-accent) 100%);
   color: transparent;
   -webkit-background-clip: text;
   background-clip: text;
-  animation: shine 3s linear infinite;
 }
 
 @keyframes shine { to { background-position: 200% center; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-button,
+  .hero-button-secondary,
+  .scroll-arrow,
+  .fade-in-content,
+  .fade-in,
+  .fade-out-content,
+  .fade-out,
+  #star-canvas {
+    animation: none;
+    transition: none;
+  }
+
+  .hero-button:hover,
+  .hero-button:focus-visible,
+  .hero-button-secondary:hover,
+  .hero-button-secondary:focus-visible {
+    transform: none;
+  }
+}
 
 @media (max-width: 900px) {
   .hero-banner { min-height: auto; padding: 92px 14px 56px; }

--- a/my-app/src/styles/components/Servicios.css
+++ b/my-app/src/styles/components/Servicios.css
@@ -1,264 +1,206 @@
-/* Variables de color */
-@import '../index.css'; 
+@import '../index.css';
+
+.servicios {
+  position: relative;
+  padding: 86px 20px;
+  background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg)), var(--section-bg-end, var(--color-bg-3)));
+  color: var(--color-text);
+  overflow-x: hidden;
+}
+
+.servicios-shell {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+}
+
+.servicios-header {
+  display: grid;
+  gap: 12px;
+  max-width: 760px;
+  margin: 0 auto 34px;
+  text-align: center;
+}
+
+.servicios-header span {
+  color: var(--color-accent);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.servicios-header h2 {
+  margin: 0;
+  color: var(--hero-title-color-2);
+  font-size: clamp(2.1rem, 4vw, 3.45rem);
+  line-height: 1.06;
+}
+
+.servicios-header p {
+  max-width: 650px;
+  margin: 0 auto;
+  color: var(--color-secondary);
+  font-size: 1.02rem;
+  line-height: 1.62;
+}
 
 .servicios-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 20px;
-  padding-left: 20px;
-  max-width: 1400px;
-  margin: 0 auto;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 18px;
   width: 100%;
-  padding-right:  20px;
 }
 
-/* Responsive */
-@media (max-width: 768px) {
-  .servicios-grid {
-    grid-template-columns: 1fr;
-    padding-left: 0px;
-    padding-right: 0px;
-  }
-}
-
-/* Contenedor principal de la sección de servicios */
-.servicios {
-  position: relative;
-  padding: 60px 20px;
-  background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg)), var(--section-bg-end, var(--color-bg-3)));
-  margin: auto;
-  min-height: 100vh;
-  overflow: hidden;
-}
-
-/* Título de la sección */
-.servicios h1 {
-  margin: 20px 0; /* Espaciado fijo alrededor del título */
-  text-align: center;
-  font-size: 3rem; /* Ajusta el tamaño del texto según necesites */
-  color: var(--hero-title-color-2);
-  position: sticky; /* Fija el título en la parte superior */
-  top: 0;
-  background-color: transparent; /* Fondo para mantener la legibilidad */
-  z-index: 100;
-  text-transform: uppercase;
-
-}
-
-/* Contenedor de cada tarjeta de servicio */
 .servicio-card {
   position: relative;
-  padding: 20px;
-  background: linear-gradient(to top, var(--color-bg-solid), var(--color-bg));
-  border-radius: 10px;
-  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-  margin-bottom: 30px;
-  transition: all 0.3s ease;
-  min-height: 350px;
-  cursor: pointer;
-  /* Añade espacio inferior si se necesita más separación entre tarjetas */
-  margin-bottom: 30px; 
+  display: flex;
+  min-width: 0;
+  min-height: 100%;
+  flex-direction: column;
+  gap: 18px;
+  padding: var(--ui-card-padding);
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card);
+  background:
+    linear-gradient(180deg, rgba(var(--hero-title-color-rgb, 125, 211, 252), 0.08), transparent 42%),
+    var(--color-bg-solid);
+  box-shadow: var(--ui-card-shadow);
+  overflow: hidden;
+  animation: methodCardIn 520ms ease both;
+  transition:
+    border-color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    transform var(--ui-transition);
 }
 
-/* Efecto de brillo en las tarjetas del portafolio */
-.servicio-card::after {
+.servicio-card:nth-child(2) { animation-delay: 80ms; }
+.servicio-card:nth-child(3) { animation-delay: 160ms; }
+.servicio-card:nth-child(4) { animation-delay: 240ms; }
+
+.servicio-card:hover,
+.servicio-card:focus-within {
+  border-color: var(--color-accent);
+  box-shadow: var(--ui-card-shadow-hover);
+  transform: translateY(-4px);
+}
+
+.servicio-card__index {
+  width: fit-content;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--color-accent);
+  color: var(--color-accent);
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}
+
+.servicio-card h3 {
+  margin: 0;
+  color: var(--hero-title-color);
+  font-size: clamp(1.25rem, 2vw, 1.55rem);
+  line-height: 1.18;
+}
+
+.bullet-clean {
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bullet-clean li {
+  position: relative;
+  padding-left: 18px;
+  color: var(--color-text);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.bullet-clean li::before {
   content: '';
   position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background: linear-gradient(to bottom right, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.2) 40%, rgba(255,255,255,0.8) 50%, rgba(255,255,255,0.2) 60%, rgba(255,255,255,0.2) 100%);
-  transform: rotate(30deg);
-  transition: all 0.5s;
-  opacity: 0;
-  pointer-events: none; /* Evitar que el efecto interfiera con la interacción */
-}
-
-.servicio-card:hover::after {
-  opacity: 1;
-  left: -100%;
-  top: -100%;
-}
-
-/* Ajuste para escalar el ícono o imagen dentro de la tarjeta, si aplica */
-.servicio-card:hover .habilidad-icono {
-  transform: scale(1.1);
-  transition: transform 0.3s ease;
-}
-
-/* Asegúrate de que la tarjeta de servicio tenga un overflow hidden para que el brillo no se salga */
-.servicio-card {
-  overflow: hidden;
-}
-
-.servicio-card.active h3 {
-  color: var(--color-text);
-}
-
-.servicio-card.active h4 {
-  color: var(--color-text);
-}
-
-.servicio-card.active .servicio-descripcion {
-  color: var(--color-text);
-}
-
-.servicio-card.active .royecto-descripcion {
-  color: var(--color-text);
-}
-
-/* Hover en la tarjeta */
-.servicio-card:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
-}
-
-/* Título del servicio */
-.servicio-card h3 {
-  color: var(--color-accent) !important;
-  font-size: 1.8rem;
-  margin-bottom: 15px;
-}
-
-.servicio-card:hover h3 {
-  transform: scale(1.02);
-  color: var(--color-accent) !important;
-  transition: transform 1s ease;
-}
-
-/* Descripción del servicio */
-.servicio-descripcion {
-  color: var(--color-secondary) !important;
-  margin-bottom: 20px;
-  line-height: 1.6;
-}
-
-/* Descripción del servicio */
-.servicio-card:hover .servicio-descripcion {
-  color: var(--color-text) !important;
-  transform: scale(1.02);
-  transition: transform 1s ease;
-}
-
-/* Listado de beneficios y tecnologías */
-.servicio-beneficios,
-.servicio-tecnologias {
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
-
-.servicio-beneficios h4,
-.servicio-tecnologias h4 {
-  color: var(--color-accent) !important;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  font-size: 1.1rem;
-}
-
-.servicio-beneficios ul,
-.servicio-tecnologias ul {
-  list-style-type: none;
-  padding-left: 0;
-  margin: 10px 0;
-}
-
-.servicio-beneficios li {
-  color: var(--color-secondary);
-  margin-bottom: 8px;
-  padding-left: 20px;
-  position: relative;
-}
-
-.servicio-beneficios li::before {
-  content: "•";
-  color: var(--color-accent);
-  position: absolute;
+  top: 0.72em;
   left: 0;
-}
-
-.servicio-tecnologias {
-  position: relative;
-  z-index: 5;
-}
-
-.servicio-tecnologias ul {
-  list-style-type: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.servicio-tecnologias li {
-  display: inline-block;
-  background: var(--color-bg-2);
-  color: var(--color-text);
-  padding: 8px 16px;
-  border-radius: 20px;
-  font-size: 0.9rem;
-  transition: all 0.3s ease;
-  cursor: pointer;
-  position: relative;
-  z-index: 10;
-  border: 1px solid transparent;
-}
-
-.servicio-tecnologias li:hover {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
   background: var(--color-accent);
-  color: white;
-  transform: translateY(-2px);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  border-color: var(--color-accent);
 }
 
-.servicio-tecnologias li:active {
-  transform: translateY(0) scale(0.98);
-}
-
-/* Contenedor de tecnologías */
-.contenedor-tecnologias {
-  margin-bottom: 80px;
-  position: relative;
-  z-index: 5;
-}
-
-/* Animación para tecnologías */
-.servicio-tecnologias li {
-  display: inline-block;
-  background: var(--color-bg-2);
-  padding: 5px 10px;
-  border-radius: 15px;
-  margin-right: 5px;
-  margin-bottom: 5px;
-  transition: all 0.3s ease;
-}
-
-.servicio-tecnologias li:hover {
-  background: var(--color-accent);
-  transform: translateY(-3px);
-  cursor: pointer;
-}
-
-.servicio-tecnologias li:active {
-  background: var(--color-accent);
-  transform: translateY(-3px) scale(0.95);
-  cursor: pointer;
-}
-
-/* Contenedor del botón de llamada a la acción */
 .servicio-cta {
-  position: absolute;
-  bottom: 20px;
-  right: 20px;
+  display: grid;
+  justify-items: center;
+  gap: 12px;
+  max-width: 760px;
+  margin: 34px auto 0;
+  padding: 26px;
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card);
+  background: var(--color-bg-solid);
+  box-shadow: var(--ui-card-shadow);
+  text-align: center;
 }
 
-/* Animación para fade in */
-@keyframes fadeInUp {
+.cta-button-3 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  max-width: 100%;
+  padding: 12px 24px;
+  border: 1px solid transparent;
+  border-radius: var(--ui-radius-pill);
+  background: var(--hero-title-color-2);
+  color: var(--color-bg-solid);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 800;
+  line-height: 1.2;
+  text-decoration: none;
+  transition:
+    background-color var(--ui-transition),
+    border-color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    color var(--ui-transition),
+    opacity var(--ui-transition),
+    transform var(--ui-transition);
+}
+
+.cta-button-3:hover,
+.cta-button-3:focus-visible {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-bg-solid);
+  box-shadow: 0 12px 24px rgba(0, 204, 153, 0.2);
+  transform: translateY(-2px);
+}
+
+.cta-button-3:focus-visible {
+  outline: 3px solid var(--ui-focus-ring);
+  outline-offset: 3px;
+}
+
+.cta-button-3:active {
+  transform: translateY(0);
+}
+
+.cta-button-3:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.cta-helper-text {
+  max-width: 560px;
+  color: var(--color-secondary);
+  font-size: 0.95rem;
+  line-height: 1.55;
+}
+
+@keyframes methodCardIn {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(18px);
   }
   to {
     opacity: 1;
@@ -266,37 +208,54 @@
   }
 }
 
-.servicio-card {
-  animation: fadeInUp 0.5s ease-out;
+@media (prefers-reduced-motion: reduce) {
+  .servicio-card {
+    animation: none;
+    transition: none;
+  }
+
+  .servicio-card:hover,
+  .servicio-card:focus-within,
+  .cta-button-3:hover,
+  .cta-button-3:focus-visible {
+    transform: none;
+  }
 }
 
-/* Estilos para los botones CTA */
-.cta-button-3 {
-  background: linear-gradient(135deg, #a80c9b, #7bcff8, #00cc99);
-  background-size: 300% 300%;
-  animation: gradientBG 10s ease infinite;
-  color: white;
-  padding: 10px 20px;
-  font-size: 1rem;
-  border: none;
-  border-radius: 20px;
-  cursor: pointer;
-  transition: transform 0.3s ease, color 0.3s ease;
-  text-decoration: none;
-  font-weight: bold;
+@media (max-width: 980px) {
+  .servicios-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
-.cta-button-3:hover {
-  background-color: var(--hero-button-hover-bg-color);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 8px rgba(0,0,0,0.3);
-  text-shadow: 0 2px 4px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2);
-  animation: gradientBG 18s ease infinite;
-}
+@media (max-width: 620px) {
+  .servicios {
+    padding: 54px 14px;
+  }
 
-.cta-button-3:active {
-  transform: scale(0.95) !important;
-  background-color: #007d66;
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3), inset 0 -1px 2px rgba(0, 0, 0, 0.2);
-  animation: none;
+  .servicios-header {
+    margin-bottom: 22px;
+    text-align: left;
+  }
+
+  .servicios-header h2 {
+    font-size: clamp(1.78rem, 8vw, 2.2rem);
+  }
+
+  .servicios-header p {
+    font-size: 0.94rem;
+  }
+
+  .servicios-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .servicio-card,
+  .servicio-cta {
+    padding: 18px;
+  }
+
+  .cta-button-3 {
+    width: 100%;
+  }
 }

--- a/my-app/src/styles/components/Soluciones.css
+++ b/my-app/src/styles/components/Soluciones.css
@@ -1,5 +1,5 @@
 .soluciones {
-  padding: 78px 20px;
+  padding: 86px 20px;
   scroll-margin-top: 96px;
   color: var(--color-text);
   background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg)), var(--section-bg-end, var(--color-bg-3)));
@@ -7,7 +7,7 @@
 
 .soluciones-header {
   max-width: 780px;
-  margin: 0 auto 32px;
+  margin: 0 auto 38px;
   text-align: center;
 }
 
@@ -40,18 +40,38 @@
 .soluciones-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 20px;
+  gap: 22px;
   max-width: 1120px;
   margin: 0 auto;
 }
 
 .soluciones-card {
+  position: relative;
   min-width: 0;
-  padding: 22px;
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  background: linear-gradient(180deg, var(--color-bg-solid), var(--color-bg));
-  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.14);
+  padding: var(--ui-card-padding);
+  border: 1px solid var(--ui-card-border);
+  border-radius: var(--ui-radius-card);
+  background:
+    linear-gradient(180deg, rgba(var(--hero-title-color-rgb, 125, 211, 252), 0.08), transparent 46%),
+    var(--color-bg-solid);
+  box-shadow: var(--ui-card-shadow);
+  overflow: hidden;
+  animation: solutionCardIn 520ms ease both;
+  transition:
+    border-color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    transform var(--ui-transition);
+}
+
+.soluciones-card:nth-child(2) { animation-delay: 80ms; }
+.soluciones-card:nth-child(3) { animation-delay: 160ms; }
+.soluciones-card:nth-child(4) { animation-delay: 240ms; }
+
+.soluciones-card:hover,
+.soluciones-card:focus-within {
+  border-color: var(--color-accent);
+  box-shadow: var(--ui-card-shadow-hover);
+  transform: translateY(-4px);
 }
 
 .soluciones-card__meta {
@@ -62,6 +82,8 @@
 }
 
 .soluciones-card__meta span {
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--color-accent);
   color: var(--color-accent);
   font-size: 0.9rem;
   font-weight: 800;
@@ -97,7 +119,7 @@
 .soluciones-card__support {
   margin-top: 14px;
   padding-top: 14px;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--ui-card-border);
   color: var(--color-secondary);
   font-size: 0.92rem;
 }
@@ -107,23 +129,73 @@
   justify-items: center;
   gap: 20px;
   max-width: 760px;
-  margin: 32px auto 0;
+  margin: 36px auto 0;
   text-align: center;
 }
 
 .soluciones-cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
   padding: 14px 30px;
-  border: none;
-  border-radius: 999px;
-  color: #ffffff;
-  background: #a80c9b;
+  border: 1px solid transparent;
+  border-radius: var(--ui-radius-pill);
+  color: var(--color-bg-solid);
+  background: var(--hero-title-color-2);
+  font: inherit;
   font-weight: 800;
   cursor: pointer;
+  transition:
+    background-color var(--ui-transition),
+    border-color var(--ui-transition),
+    box-shadow var(--ui-transition),
+    color var(--ui-transition),
+    opacity var(--ui-transition),
+    transform var(--ui-transition);
 }
 
 .soluciones-cta:hover,
 .soluciones-cta:focus {
-  background: #7a0871;
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  box-shadow: 0 12px 24px rgba(0, 204, 153, 0.2);
+  transform: translateY(-2px);
+}
+
+.soluciones-cta:focus-visible {
+  outline: 3px solid var(--ui-focus-ring);
+  outline-offset: 3px;
+}
+
+.soluciones-cta:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+@keyframes solutionCardIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .soluciones-card {
+    animation: none;
+    transition: none;
+  }
+
+  .soluciones-card:hover,
+  .soluciones-card:focus-within,
+  .soluciones-cta:hover,
+  .soluciones-cta:focus {
+    transform: none;
+  }
 }
 
 @media (max-width: 900px) {
@@ -135,11 +207,12 @@
 
 @media (max-width: 520px) {
   .soluciones {
-    padding: 42px 14px 48px;
+    padding: 54px 14px;
   }
 
   .soluciones-header {
     margin-bottom: 20px;
+    text-align: left;
   }
 
   .soluciones-header h2 {
@@ -153,7 +226,7 @@
   }
 
   .soluciones-card {
-    padding: 16px;
+    padding: 18px;
   }
 
   .soluciones-card__meta {

--- a/my-app/src/styles/index.css
+++ b/my-app/src/styles/index.css
@@ -25,6 +25,19 @@
   --color-border-dark: #444444; /* Bordes oscuros para modo oscuro */
   --color-bg-footer: #121212;
 
+  --ui-radius-card: 12px;
+  --ui-radius-card-sm: 8px;
+  --ui-radius-pill: 999px;
+  --ui-card-padding: 24px;
+  --ui-card-border-light: rgba(2, 8, 23, 0.12);
+  --ui-card-border-dark: rgba(246, 249, 252, 0.16);
+  --ui-card-shadow-light: 0 18px 42px rgba(2, 8, 23, 0.12);
+  --ui-card-shadow-dark: 0 22px 50px rgba(0, 0, 0, 0.34);
+  --ui-card-shadow-hover-light: 0 24px 54px rgba(2, 8, 23, 0.16);
+  --ui-card-shadow-hover-dark: 0 28px 60px rgba(0, 0, 0, 0.42);
+  --ui-focus-ring: rgba(125, 211, 252, 0.55);
+  --ui-transition: 180ms ease;
+
   --color-bg-dark: #020817;
   --color-text-dark: #f6f9fc;
   --color-primary-dark: #7dd3fc;
@@ -61,6 +74,9 @@
   --color-bg-solid: var(--color-bg-solid-dark);
   --color-shadow: var(--color-shadow-dark);
   --color-border: var(--color-border-dark);
+  --ui-card-border: var(--ui-card-border-dark);
+  --ui-card-shadow: var(--ui-card-shadow-dark);
+  --ui-card-shadow-hover: var(--ui-card-shadow-hover-dark);
   --hero-title-color: var(--hero-title-color-dark);
   --hero-title-color-rgb: var(--hero-title-color-dark-rgb);
   --color-bg-footer: var(--color-bg-footer);
@@ -87,6 +103,9 @@
   --color-bg-solid: var(--color-bg-solid-light);
   --color-shadow: var(--color-shadow-light);
   --color-border: var(--color-border-light);
+  --ui-card-border: var(--ui-card-border-light);
+  --ui-card-shadow: var(--ui-card-shadow-light);
+  --ui-card-shadow-hover: var(--ui-card-shadow-hover-light);
   --hero-title-color: var(--hero-title-color-light);
   --hero-title-color-rgb: var(--hero-title-color-light-rgb);
   --color-bg-footer: var(--color-bg-footer);


### PR DESCRIPTION
## What changed
- Unified the visual system across Hero, Soluciones, Casos reales, Como trabajo, and Contacto.
- Added shared UI tokens for card radius, shadows, borders, focus rings, transitions, and CTA behavior.
- Rebuilt Como trabajo as a clearer method section while preserving the four content blocks and Contacto CTA.
- Removed the Hero negative copy `sin humo` / `without fluff` and replaced it with positive clarity/execution language.

## Visual pattern
- Used Carrera as the reference for sober progressive entry, deeper cards, clear hierarchy, and restrained interaction.
- Kept cards in the same family without forcing identical layouts across different section jobs.

## Validation
- `npm test -- --runInBand --watchAll=false` -> 11 suites / 37 tests passed.
- `npm run build` -> compiled successfully after stopping the local static server that had locked `build/`; generated files were restored afterward.
- `git diff --check` -> no whitespace errors; only CRLF warnings from Git.
- Browser QA on local build: desktop/mobile, ES/EN, light/dark, section anchors, no horizontal overflow, focus-visible CTAs, reduced-motion CSS present.

## Notes
- DevTools reported CORB issues for external resources during one QA pass, but no console `error` or `warn` messages were present in the final build verification.
- No changes to navigation, footer, routes, SEO, sitemap, robots, data files, endpoint, payload, dependencies, assets, CV, workers, or Core DB.
