### PR TITLE
Iteración 9: coherencia bilingüe y CTAs

### DIFF
--- a/my-app/src/components/CasosEstudio.js
+++ b/my-app/src/components/CasosEstudio.js
@@ -9,7 +9,7 @@ const content = {
     eyebrow: 'Casos reales',
     title: 'De un reto concreto a algo que ya funciona',
     description: 'Estrategia, tecnología y operación alineadas para generar resultados medibles.',
-    cta: 'Hablemos de tu reto →',
+    cta: 'Ver cómo lo resolví →',
     labels: {
       challenge: 'Reto',
       built: 'Construcción',
@@ -44,7 +44,7 @@ const content = {
     eyebrow: 'Real work',
     title: 'From a concrete challenge to something that works',
     description: 'Strategy, technology and operations aligned to generate measurable results.',
-    cta: 'Let’s talk about your challenge →',
+    cta: 'See how I solved it →',
     labels: {
       challenge: 'Challenge',
       built: 'Build',

--- a/my-app/src/components/CasosEstudio.js
+++ b/my-app/src/components/CasosEstudio.js
@@ -9,7 +9,7 @@ const content = {
     eyebrow: 'Casos reales',
     title: 'De un reto concreto a algo que ya funciona',
     description: 'Estrategia, tecnología y operación alineadas para generar resultados medibles.',
-    cta: 'Ver cómo lo resolví →',
+    cta: 'Cuéntame qué quieres resolver →',
     labels: {
       challenge: 'Reto',
       built: 'Construcción',
@@ -44,7 +44,7 @@ const content = {
     eyebrow: 'Real work',
     title: 'From a concrete challenge to something that works',
     description: 'Strategy, technology and operations aligned to generate measurable results.',
-    cta: 'See how I solved it →',
+    cta: 'Tell me what you want to solve →',
     labels: {
       challenge: 'Challenge',
       built: 'Build',

--- a/my-app/src/components/CasosEstudio.test.js
+++ b/my-app/src/components/CasosEstudio.test.js
@@ -113,7 +113,26 @@ describe('CasosEstudio', () => {
     const { container, cleanup } = renderCasosEstudio('es');
     const cta = container.querySelector('.casos-estudio__cta');
 
-    expect(cta.textContent).toContain('Ver cómo lo resolví');
+    expect(cta.textContent).toContain('Cuéntame qué quieres resolver');
+
+    act(() => {
+      cta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(contacto.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+    cleanup();
+  });
+
+  it('shows the approved English lower CTA copy while keeping the same contact scroll', () => {
+    const contacto = document.createElement('section');
+    contacto.id = 'contacto';
+    document.body.appendChild(contacto);
+
+    const { container, cleanup } = renderCasosEstudio('en');
+    const cta = container.querySelector('.casos-estudio__cta');
+
+    expect(cta.textContent).toContain('Tell me what you want to solve');
 
     act(() => {
       cta.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/my-app/src/components/CasosEstudio.test.js
+++ b/my-app/src/components/CasosEstudio.test.js
@@ -113,6 +113,8 @@ describe('CasosEstudio', () => {
     const { container, cleanup } = renderCasosEstudio('es');
     const cta = container.querySelector('.casos-estudio__cta');
 
+    expect(cta.textContent).toContain('Ver cómo lo resolví');
+
     act(() => {
       cta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });

--- a/my-app/src/components/HeroBanner.js
+++ b/my-app/src/components/HeroBanner.js
@@ -24,12 +24,12 @@ const DynamicHeroBanner = ({ style }) => {
     ],
     en: [
       {
-        title: 'I turn your business idea into a working digital product in weeks, not months',
+        title: 'I turn complex business processes into digital solutions that actually work',
         subtitle: 'Ex-COO at GoFarma and Digital Product Owner at CHUBB.',
-        description: 'Strategy, prototype and real metrics to validate, automate or unblock an operational challenge with clarity and visible execution.',
+        description: 'I combine operations, product thinking and practical technology to help teams move faster, make better decisions and solve real business problems.',
         icon: '🧪',
         cta: 'Let’s talk about your challenge',
-        secondaryCta: 'See real cases'
+        secondaryCta: 'Explore real projects'
       }
     ]
   }), []);

--- a/my-app/src/components/HeroBanner.test.js
+++ b/my-app/src/components/HeroBanner.test.js
@@ -88,7 +88,7 @@ describe('HeroBanner', () => {
     cleanup();
   });
 
-  it('keeps the existing English headline and shows the updated English CTA', () => {
+  it('uses the approved English hero positioning and CTA copy', () => {
     const soluciones = document.createElement('section');
     soluciones.id = 'soluciones';
     soluciones.scrollIntoView = jest.fn();
@@ -96,10 +96,13 @@ describe('HeroBanner', () => {
 
     const { container, cleanup } = renderHero('en');
 
-    expect(container.textContent).toContain('I turn your business idea into a working digital product in weeks, not months');
-    expect(container.textContent).toContain('with clarity and visible execution');
-    expect(container.textContent).not.toContain('without fluff');
+    expect(container.textContent).toContain('I turn complex business processes into digital solutions that actually work');
+    expect(container.textContent).toContain('I combine operations, product thinking and practical technology');
+    expect(container.textContent).toContain('help teams move faster, make better decisions and solve real business problems');
+    expect(container.textContent).not.toContain('working digital product in weeks, not months');
+    expect(container.textContent).not.toContain('turn your business idea into a working digital product');
     expect(container.querySelector('.hero-button').textContent).toContain('Let’s talk about your challenge');
+    expect(container.querySelector('.hero-button-secondary').textContent).toContain('Explore real projects');
     expect(container.querySelector('.scroll-indicator').textContent).toContain('See solutions');
     expect(container.innerHTML).not.toContain('calendly.com');
 

--- a/my-app/src/components/Portafolio.js
+++ b/my-app/src/components/Portafolio.js
@@ -221,14 +221,14 @@ const Portafolio = ({ style }) => {
       title: '¿Te imaginas tu proyecto en este portafolio?',
       description:
         'Trabajemos juntos para diseñar una solución a medida, desde la estrategia hasta la implementación.',
-      primary: 'Solicitar una reunión',
+      primary: 'Hablemos de tu proyecto',
       secondary: 'Conoce cómo trabajo'
     },
     en: {
       title: 'Ready to see your project featured here?',
       description:
         'Let’s craft a tailored solution together—from strategic planning to hands-on implementation.',
-      primary: 'Request a meeting',
+      primary: "Let's talk about your project",
       secondary: 'See how I work'
     }
   };

--- a/my-app/src/components/Portafolio.test.js
+++ b/my-app/src/components/Portafolio.test.js
@@ -70,12 +70,30 @@ describe('Portafolio CTA', () => {
   });
 
   it('labels the primary CTA as a contact action in both languages', () => {
+    const contacto = document.createElement('section');
+    contacto.id = 'contacto';
+    contacto.scrollIntoView = jest.fn();
+    document.body.appendChild(contacto);
+
     const { container: esContainer, cleanup: cleanupEs } = renderPortafolio('es');
-    expect(esContainer.querySelector('.cta-button-primary').textContent).toContain('Hablemos de tu proyecto');
+    const esPrimaryCta = esContainer.querySelector('.cta-button-primary');
+    expect(esPrimaryCta.textContent).toContain('Hablemos de tu proyecto');
+    act(() => {
+      esPrimaryCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(contacto.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
     cleanupEs();
 
+    contacto.scrollIntoView.mockClear();
     const { container: enContainer, cleanup: cleanupEn } = renderPortafolio('en');
-    expect(enContainer.querySelector('.cta-button-primary').textContent).toContain("Let's talk about your project");
+    const enPrimaryCta = enContainer.querySelector('.cta-button-primary');
+    expect(enPrimaryCta.textContent).toContain("Let's talk about your project");
+    act(() => {
+      enPrimaryCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(contacto.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
     cleanupEn();
+
+    contacto.remove();
   });
 });

--- a/my-app/src/components/Portafolio.test.js
+++ b/my-app/src/components/Portafolio.test.js
@@ -68,4 +68,14 @@ describe('Portafolio CTA', () => {
 
     cleanup();
   });
+
+  it('labels the primary CTA as a contact action in both languages', () => {
+    const { container: esContainer, cleanup: cleanupEs } = renderPortafolio('es');
+    expect(esContainer.querySelector('.cta-button-primary').textContent).toContain('Hablemos de tu proyecto');
+    cleanupEs();
+
+    const { container: enContainer, cleanup: cleanupEn } = renderPortafolio('en');
+    expect(enContainer.querySelector('.cta-button-primary').textContent).toContain("Let's talk about your project");
+    cleanupEn();
+  });
 });

--- a/my-app/src/components/SobreMi.js
+++ b/my-app/src/components/SobreMi.js
@@ -54,22 +54,18 @@ function SobreMi({ style }) {
         ),
       },
       {
-        title: 'Cómo trabajo',
+        title: 'Mi enfoque',
         image: tech_vision,
-        alt: 'Cómo trabajo',
-        subtitle: 'Entender el sistema, elegir qué mover primero y acompañar la ejecución.',
+        alt: 'Mi enfoque',
+        subtitle: 'La solución correcta empieza por entender qué está frenando al negocio.',
         content: (
           <div className="content-container">
             <div className="image-container">
-              <LazyLoadImage src={tech_vision} alt="Cómo trabajo" width={500} height={500} effect="blur" placeholderSrc={tech_vision} className="optimized-image" />
+              <LazyLoadImage src={tech_vision} alt="Mi enfoque" width={500} height={500} effect="blur" placeholderSrc={tech_vision} className="optimized-image" />
             </div>
             <div className="text-content">
-              <h3>1. Aterrizamos el reto</h3>
-              <p>Empiezo por entender qué ocurre en la operación, con las personas y frente al cliente. No parto de una herramienta.</p>
-              <h3>2. Diseñamos lo necesario</h3>
-              <p>Definimos proceso, alcance, experiencia y medición antes de construir más de la cuenta.</p>
-              <h3>3. Lo llevamos a uso real</h3>
-              <p>Conecto decisiones, tecnología y equipos para que la solución se adopte, se mida y mejore con evidencia.</p>
+              <p>Mi experiencia me enseñó que una buena solución no empieza con tecnología, sino con entender qué está frenando al negocio.</p>
+              <p>Por eso conecto operación, producto y ejecución antes de llevar el trabajo completo a la sección dedicada más abajo.</p>
             </div>
           </div>
         ),
@@ -116,22 +112,18 @@ function SobreMi({ style }) {
         ),
       },
       {
-        title: 'How I work',
+        title: 'My approach',
         image: tech_vision,
-        alt: 'How I work',
-        subtitle: 'Understand the system, decide what to move first and stay close to execution.',
+        alt: 'My approach',
+        subtitle: 'The right solution starts with understanding what is slowing the business down.',
         content: (
           <div className="content-container">
             <div className="image-container">
-              <LazyLoadImage src={tech_vision} alt="How I work" width={500} height={500} effect="blur" placeholderSrc={tech_vision} className="optimized-image" />
+              <LazyLoadImage src={tech_vision} alt="My approach" width={500} height={500} effect="blur" placeholderSrc={tech_vision} className="optimized-image" />
             </div>
             <div className="text-content">
-              <h3>1. Ground the challenge</h3>
-              <p>I start by understanding what is happening in the operation, with the people involved and for the customer. I do not start with a tool.</p>
-              <h3>2. Design what is needed</h3>
-              <p>We define process, scope, experience and measurement before building more than necessary.</p>
-              <h3>3. Bring it into real use</h3>
-              <p>I connect decisions, technology and teams so the solution is adopted, measured and improved with evidence.</p>
+              <p>I have learned that good solutions do not start with technology. They start by understanding what is slowing the business down.</p>
+              <p>That is why I connect operations, product and execution before moving the full work to the dedicated section below.</p>
             </div>
           </div>
         ),
@@ -217,7 +209,7 @@ function SobreMi({ style }) {
           {sections[language][currentSection].content}
         </div>
         <div className="cta-seccion-sobre-mi">
-          <button onClick={scrollToServicios} className="cta-button-2">{language === 'es' ? 'Ver método' : 'See method'}</button>
+          <button onClick={scrollToServicios} className="cta-button-2">{language === 'es' ? 'Conoce cómo trabajo' : 'See how I work'}</button>
           <button onClick={scrollToContacto} className="cta-button-2">{language === 'es' ? 'Hablemos de tu reto' : 'Let’s talk about your challenge'}</button>
         </div>
         <div className="horizontal-scroll-indicator">

--- a/my-app/src/components/SobreMi.test.js
+++ b/my-app/src/components/SobreMi.test.js
@@ -43,7 +43,7 @@ describe('SobreMi', () => {
     document.body.innerHTML = '';
   });
 
-  it('sends method and conversation CTAs to the approved sections', () => {
+  it('keeps the method reference brief and links it to como-trabajo', () => {
     const metodo = document.createElement('section');
     metodo.id = 'como-trabajo';
     metodo.scrollIntoView = jest.fn();
@@ -55,12 +55,23 @@ describe('SobreMi', () => {
     document.body.appendChild(contacto);
 
     const { container, cleanup } = renderSobreMi('es');
-    const methodCta = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Ver método');
+    const approachTab = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Mi enfoque');
+    const methodCta = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Conoce cómo trabajo');
     const contactCta = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Hablemos de tu reto');
 
+    expect(approachTab).toBeTruthy();
     expect(methodCta).toBeTruthy();
     expect(contactCta).toBeTruthy();
-    expect(container.textContent).not.toContain('Recibe diagnóstico');
+
+    act(() => {
+      approachTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Mi experiencia me enseñó que una buena solución no empieza con tecnología');
+    expect(container.textContent).toContain('Por eso conecto operación, producto y ejecución');
+    expect(container.textContent).not.toContain('1. Aterrizamos el reto');
+    expect(container.textContent).not.toContain('2. Diseñamos lo necesario');
+    expect(container.textContent).not.toContain('3. Lo llevamos a uso real');
 
     act(() => {
       methodCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -69,6 +80,38 @@ describe('SobreMi', () => {
 
     expect(metodo.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
     expect(contacto.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+
+    cleanup();
+  });
+
+  it('keeps the English about-me reference brief and points to How I work', () => {
+    const metodo = document.createElement('section');
+    metodo.id = 'como-trabajo';
+    metodo.scrollIntoView = jest.fn();
+    document.body.appendChild(metodo);
+
+    const { container, cleanup } = renderSobreMi('en');
+    const approachTab = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'My approach');
+    const methodCta = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'See how I work');
+
+    expect(approachTab).toBeTruthy();
+    expect(methodCta).toBeTruthy();
+
+    act(() => {
+      approachTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('I have learned that good solutions do not start with technology');
+    expect(container.textContent).toContain('That is why I connect operations, product and execution');
+    expect(container.textContent).not.toContain('1. Ground the challenge');
+    expect(container.textContent).not.toContain('2. Design what is needed');
+    expect(container.textContent).not.toContain('3. Bring it into real use');
+
+    act(() => {
+      methodCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(metodo.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
 
     cleanup();
   });

--- a/my-app/src/components/Testimonios.test.js
+++ b/my-app/src/components/Testimonios.test.js
@@ -103,7 +103,7 @@ describe('Testimonios', () => {
   it('renders the three approved quote extracts without banned filler copy', () => {
     const { container, cleanup } = renderWithLanguage(<Testimonios />, 'es');
 
-    expect(container.textContent).toContain('Elier stood out for his objectivity, commitment, continuous improvement focus and excellent data analysis. He is a dedicated leader, always working with teams to optimize processes and deliver results.');
+    expect(container.textContent).toContain('Elier se destacó por su objetividad, compromiso, enfoque de mejora continua y excelente análisis de datos. Es un líder dedicado, siempre trabajando con los equipos para optimizar procesos y entregar resultados.');
     expect(container.textContent).toContain('Elier tiene una admirable capacidad de auto-aprendizaje y siempre está buscando cómo mejorar y automatizar procesos. Es una persona confiable, que se rige por principios y valores ante cualquier circunstancia.');
     expect(container.textContent).toContain('No sólo te enfocas en que algo se vea bonito, sino en entender el problema, pensar en las personas que lo van a usar y construir algo que realmente funcione. OneClicTrip hoy tiene mucho más dirección gracias a ti.');
     expect(container.textContent).not.toContain('referencias en proceso');
@@ -116,7 +116,7 @@ describe('Testimonios', () => {
     cleanup();
   });
 
-  it('uses the approved LinkedIn links and keeps Ilse without an external link', () => {
+  it('uses the approved LinkedIn links for all three testimonials', () => {
     const { container, cleanup } = renderWithLanguage(<Testimonios />, 'es');
 
     const links = Array.from(container.querySelectorAll('a'));
@@ -124,14 +124,9 @@ describe('Testimonios', () => {
 
     expect(hrefs).toContain('https://www.linkedin.com/in/edgar-tienda/?locale=en');
     expect(hrefs).toContain('https://www.linkedin.com/in/gloriahiguera/');
-    expect(links.filter((link) => link.textContent === 'Ver en LinkedIn')).toHaveLength(2);
+    expect(hrefs).toContain('https://www.linkedin.com/in/ilse-jasso/en/');
+    expect(links.filter((link) => link.textContent === 'Ver en LinkedIn')).toHaveLength(3);
     expect(container.textContent).not.toContain('Fuente');
-
-    const ilseCard = Array.from(container.querySelectorAll('.testimonios__card')).find((card) =>
-      card.textContent.includes('Ilse Jasso')
-    );
-
-    expect(ilseCard.querySelector('a')).toBeNull();
 
     cleanup();
   });


### PR DESCRIPTION
Ajusta el copy bilingüe para alinear el hero con el posicionamiento de procesos/operaciones/soluciones prácticas, reduce la duplicación del método dentro de Sobre Mí y hace más específicos los CTAs secundarios.

Verificado con:
- npm test -- --runInBand --watchAll=false
- npm run build
- git diff --check

Nota: se restauró `src/config/hashedPasscodes.js` después del build, como pide la iteración.