### PR TITLE
[codex] Redesign career timeline

### DIFF
--- a/my-app/src/components/Portafolio.js
+++ b/my-app/src/components/Portafolio.js
@@ -1,16 +1,275 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import '../styles/components/Portafolio.css';
 import '../styles/components/Timeline.css';
 import { getCurrentLanguage } from './utils/languageUtils';
 
-// Import images
-import wonderlabsImg from '../assets/images/wonderlabs.jpg';
-import elelierImg from '../assets/images/elelier.jpg';
 import chubbImg from '../assets/images/CHUBB.jpg';
-import gofarmaImg from '../assets/images/gofarma.jpg';
+import elelierImg from '../assets/images/elelier.jpg';
 import farmalistoImg from '../assets/images/farmalisto.jpg';
-import pepsicoImg from '../assets/images/pepsico.jpg';
+
+const LINKEDIN_URL = 'https://linkedin.com/in/elier/';
+
+const careerContent = {
+  es: [
+    {
+      id: 'gofarma-farmalisto',
+      name: 'GoFarma + Farmalisto',
+      period: '2016–2024',
+      role: 'Operación, producto digital y crecimiento comercial',
+      description:
+        'Convertí procesos operativos complejos en una operación más precisa, rápida y medible.',
+      bannerAlt: 'Banner de Farmalisto con enfoque en operación y crecimiento comercial',
+      image: farmalistoImg,
+      chips: [
+        '99.8% precisión de inventario',
+        'Pedidos en ~2 min',
+        '−50% reclamaciones y cancelaciones',
+        '+144% ventas',
+        '+58% ticket promedio'
+      ],
+      links: [
+        {
+          label: 'Ver Farmalisto ↗',
+          href: 'https://www.farmalisto.com.mx/'
+        }
+      ],
+      bullets: [
+        'Diseñé procesos de inventario, operación y fulfillment.',
+        'Estandaricé flujos para reducir reclamos y cancelaciones.',
+        'Llevé operación y marketplaces a decisiones más medibles.'
+      ]
+    },
+    {
+      id: 'chubb',
+      name: 'CHUBB',
+      period: '2024–Actualidad',
+      role: 'Digital Product Owner',
+      description:
+        'Lidero iniciativas de producto y transformación digital para mejorar experiencia, operación y toma de decisiones.',
+      bannerAlt: 'Banner de CHUBB con enfoque en producto digital',
+      image: chubbImg,
+      chips: ['Producto digital', 'Operación', 'Transformación', 'Usabilidad', 'Datos'],
+      links: [
+        {
+          label: 'Ver LinkedIn ↗',
+          href: LINKEDIN_URL
+        }
+      ],
+      bullets: [
+        'Digitalización de renovaciones de pólizas.',
+        'Mejora de cotización, emisión y experiencia de usuario.',
+        'Uso de datos y usabilidad para priorizar decisiones.'
+      ]
+    },
+    {
+      id: 'elier',
+      name: 'Elier',
+      period: '2025–Actualidad',
+      role: 'Producto y transformación digital',
+      description:
+        'Ayudo a negocios y equipos a aterrizar retos en soluciones digitales útiles, claras y accionables.',
+      bannerAlt: 'Banner de Elier con enfoque en producto y transformación digital',
+      image: elelierImg,
+      chips: ['Automatización', 'IA aplicada', 'Producto', 'Integraciones', 'Consultoría'],
+      links: [
+        {
+          label: 'Ver elelier.com ↗',
+          href: 'https://elelier.com/'
+        },
+        {
+          label: 'LinkedIn ↗',
+          href: LINKEDIN_URL
+        }
+      ],
+      bullets: [
+        'Diseño y construcción de soluciones digitales.',
+        'Automatización e IA aplicada a retos concretos.',
+        'Integración entre operación, producto y ejecución.'
+      ]
+    }
+  ],
+  en: [
+    {
+      id: 'gofarma-farmalisto',
+      name: 'GoFarma + Farmalisto',
+      period: '2016–2024',
+      role: 'Operations, digital product and commercial growth',
+      description:
+        'I turned complex operational processes into a more accurate, faster and measurable operation.',
+      bannerAlt: 'Farmalisto banner focused on operations and commercial growth',
+      image: farmalistoImg,
+      chips: [
+        '99.8% inventory accuracy',
+        'Orders in ~2 min',
+        '−50% claims and cancellations',
+        '+144% sales',
+        '+58% average ticket'
+      ],
+      links: [
+        {
+          label: 'View Farmalisto ↗',
+          href: 'https://www.farmalisto.com.mx/'
+        }
+      ],
+      bullets: [
+        'Designed inventory, operations and fulfillment processes.',
+        'Standardized flows to reduce claims and cancellations.',
+        'Brought operations and marketplaces into more measurable decision-making.'
+      ]
+    },
+    {
+      id: 'chubb',
+      name: 'CHUBB',
+      period: '2024–Present',
+      role: 'Digital Product Owner',
+      description:
+        'I lead product and digital transformation initiatives to improve experience, operations and decision-making.',
+      bannerAlt: 'CHUBB banner focused on digital product work',
+      image: chubbImg,
+      chips: ['Digital product', 'Operations', 'Transformation', 'Usability', 'Data'],
+      links: [
+        {
+          label: 'View LinkedIn ↗',
+          href: LINKEDIN_URL
+        }
+      ],
+      bullets: [
+        'Digitalization of policy renewal processes.',
+        'Improvement of quoting, issuance and user experience.',
+        'Use of data and usability to prioritize decisions.'
+      ]
+    },
+    {
+      id: 'elier',
+      name: 'Elier',
+      period: '2025–Present',
+      role: 'Product and digital transformation',
+      description:
+        'I help businesses and teams turn challenges into useful, clear and actionable digital solutions.',
+      bannerAlt: 'Elier banner focused on product and digital transformation',
+      image: elelierImg,
+      chips: ['Automation', 'Applied AI', 'Product', 'Integrations', 'Consulting'],
+      links: [
+        {
+          label: 'View elelier.com ↗',
+          href: 'https://elelier.com/'
+        },
+        {
+          label: 'LinkedIn ↗',
+          href: LINKEDIN_URL
+        }
+      ],
+      bullets: [
+        'Design and delivery of digital solutions.',
+        'Automation and applied AI for concrete challenges.',
+        'Integration across operations, product and execution.'
+      ]
+    }
+  ]
+};
+
+const ctaContent = {
+  es: {
+    title: '¿Te imaginas tu proyecto en este portafolio?',
+    description:
+      'Trabajemos juntos para diseñar una solución a medida, desde la estrategia hasta la implementación.',
+    primary: 'Hablemos de tu proyecto',
+    secondary: 'Conoce cómo trabajo'
+  },
+  en: {
+    title: 'Ready to see your project featured here?',
+    description:
+      'Let’s craft a tailored solution together—from strategic planning to hands-on implementation.',
+    primary: "Let's talk about your project",
+    secondary: 'See how I work'
+  }
+};
+
+function CareerCard({ entry, index, language, isExpanded, onToggle }) {
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onToggle(index);
+    }
+  };
+
+  const stopPropagation = (event) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <article
+      className={`timeline-card${isExpanded ? ' timeline-card--expanded' : ''}`}
+      role="button"
+      tabIndex={0}
+      aria-expanded={isExpanded}
+      data-testid="career-card"
+      data-career-name={entry.name}
+      onClick={() => onToggle(index)}
+      onKeyDown={handleKeyDown}
+      aria-label={`${entry.name} ${entry.period}`}
+    >
+      <span className="timeline-card__period">{entry.period}</span>
+
+      <div className="timeline-card__banner">
+        <img src={entry.image} alt={entry.bannerAlt} className="timeline-card__image" />
+        <div className="timeline-card__overlay" aria-hidden="true" />
+      </div>
+
+      <div className="timeline-card__body">
+        <div className="timeline-card__identity">
+          <h3>{entry.name}</h3>
+          <h4>{entry.role}</h4>
+          <p>{entry.description}</p>
+        </div>
+
+        <div className="timeline-card__chips" aria-label={language === 'es' ? 'Logros destacados' : 'Highlighted achievements'}>
+          {entry.chips.map((chip) => (
+            <span key={chip} className="timeline-card__chip">
+              {chip}
+            </span>
+          ))}
+        </div>
+
+        <div className="timeline-card__links">
+          {entry.links.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={stopPropagation}
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+
+        {isExpanded && (
+          <div className="timeline-card__details">
+            <h5>{language === 'es' ? 'Lo que moví' : 'What I moved'}</h5>
+            <ul>
+              {entry.bullets.map((bullet) => (
+                <li key={bullet}>{bullet}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <span className="timeline-card__toggle">
+          {isExpanded
+            ? language === 'es'
+              ? 'Ocultar detalles ↑'
+              : 'Hide details ↑'
+            : language === 'es'
+              ? 'Ver detalles ↓'
+              : 'View details ↓'}
+        </span>
+      </div>
+    </article>
+  );
+}
 
 const Portafolio = ({ style }) => {
   const [activeIndex, setActiveIndex] = useState(null);
@@ -29,211 +288,63 @@ const Portafolio = ({ style }) => {
   }, []);
 
   useEffect(() => {
-    setCurrentLang(getCurrentLanguage());
+    setCurrentLang(language || getCurrentLanguage());
   }, [language]);
 
-  const proyectos = {
-    es: [
-      {
-        nombre: "CHUBB",
-        timeline: "2024 - Actualidad",
-        rol: "Digital Product Owner",
-        image: chubbImg,
-        descripcion: "Impulso la transformación digital en CHUBB, liderando la digitalización y optimización en el área de renovaciones de pólizas para mejorar la experiencia del cliente y la eficiencia operativa.",
-        logros: [
-          "Implementación de automatización y personalización en procesos de renovación para flotas e individuales",
-          "Desarrollo de una nueva interfaz de renovación y optimización de cotización y emisión",
-          "Integración de análisis de datos y estudios de usabilidad para decisiones estratégicas y mejora continua"
-        ],
-        tecnologias: ["Agile", "Automatización", "Digital Transformation", "Data Analytics", "UX/UI"],
-        link: "https://www.chubb.com",
-        link_u: "chubb.com"
-      },
-      {
-        nombre: "Freelancer",
-        timeline: "2024 - Actualidad",
-        rol: "Ingeniero en transformación digital",
-        image: elelierImg,
-        descripcion: "Desarrollé asistentes de IA enfocados en marketing y gestión de proyectos, mejorando la eficacia de estrategias de marca y la planificación de proyectos.",
-        logros: [
-          "Creación de un asistente para generar ideas innovadoras de campañas publicitarias",
-          "Desarrollo de un asistente para planificar, actualizar y evaluar proyectos",
-          "Implementación de funciones para mantener la motivación y el enfoque en los logros"
-        ],
-        tecnologias: ["HuggingFace", "Procesamiento de Lenguaje Natural", "Machine Learning", "Python"],
-        link: "https://huggingface.co/chat/assistants?user=Elelier",
-        link_u: "huggingface.co"
-      },
-      {
-        nombre: "Wonderlabs",
-        timeline: "2023-2024",
-        rol: "Desarrollador Backend Senior",
-        image: wonderlabsImg,
-        descripcion: "Desarrollé la infraestructura backend de una plataforma que genera cuentos personalizados para niños, integrando IA avanzada para la generación automática de historias, imágenes y narraciones.",
-        logros: [
-          "Desarrollo de API's para gestionar los flujos esenciales, como bases de datos, generación de historias, imágenes y narraciones con IA",
-          "Configuración y optimización del sitio web dinámico utilizando WIX para una experiencia de usuario fluida",
-          "Implementación de un chatbot para atención al cliente utilizando inteligencia artificial avanzada"
-        ],
-        tecnologias: ["React", "Node.js", "Desarrollo de API", "IA Generativa", "WIX"],
-        link: "https://wonderlabs.studio",
-        link_u: "wonderlabs.studio"
-      },
+  useEffect(() => {
+    const section = document.getElementById('portafolio');
 
-      {
-        nombre: "GoFarma",
-        timeline: "2016-2024",
-        rol: "Co-fundador y Director de Operaciones",
-        image: gofarmaImg,
-        descripcion: "Diseñé e implementé el modelo operativo de la compañía, logrando una precisión de inventario del 99.8% y tiempos de entrega competitivos.",
-        logros: [
-          "Precisión del inventario del 99.8%",
-          "Tiempo de procesamiento por pedido de 2 minutos",
-          "Optimización de envíos locales y nacionales"
-        ],
-        tecnologias: ["ERP Olimpo", "Automatización de procesos", "Gestión de inventarios"],
-        link: "http://www.gofarma.com",
-        link_u: "gofarma.com"
-      },
-      {
-        nombre: "Farmalisto",
-        timeline: "2022-2024",
-        rol: "Director de Ventas en Marketplaces",
-        image: farmalistoImg,
-        descripcion: "Gestioné la presencia en línea en diversos marketplaces, aumentando la visibilidad y conversión de clientes.",
-        logros: [
-          "Reducción del 50% en reclamos y cancelaciones",
-          "Incremento del 144% en ventas",
-          "Aumento del 58% en ticket promedio"
-        ],
-        tecnologias: ["Mercado Libre", "Amazon", "Shopify", "NetSuite ERP", "IA para atención al cliente"],
-        link: "https://www.farmalisto.com.mx/",
-        link_u: "farmalisto.com.mx"
-      },
-      {
-        nombre: "PepsiCo",
-        timeline: "2012-2016",
-        rol: "Coordinador de Proyectos de Productividad",
-        image: pepsicoImg,
-        descripcion: "Lideré proyectos de mejora en 8 plantas de Gamesa-Quaker, optimizando procesos y aumentando la eficiencia.",
-        logros: [
-          "Incremento del rendimiento de materia prima en un 0.4% a nivel nacional",
-          "Implementación de KPIs y gestión de proyectos de aumento de capacidad"
-        ],
-        tecnologias: ["SAP", "Metodología DMAIC", "Lean Six Sigma"]
-      }
-    ],
-    en: [
-      {
-        // English version
-        nombre: "CHUBB",
-        timeline: "2024 - Present",
-        rol: "Digital Product Owner",
-        image: chubbImg,
-        descripcion: "I drive digital transformation at CHUBB by optimizing policy renewal processes to enhance customer experience and operational efficiency.",
-        logros: [
-          "Implemented automation and customization for fleet and individual policy renewals",
-          "Developed a new renewal interface and optimized quoting and issuance processes",
-          "Integrated data analytics and usability studies for strategic decision-making and continuous improvement"
-        ],
-        tecnologias: ["Agile", "Automation", "Digital Transformation", "Data Analytics", "UX/UI"],
-        link: "https://www.chubb.com",
-        link_u: "chubb.com"
-      },
-      {
-        nombre: "Virtual Assistants",
-        timeline: "2024",
-        rol: "AI Developer",
-        image: elelierImg,
-        descripcion: "Developed AI assistants focused on marketing and project management, improving brand strategy effectiveness and project planning.",
-        logros: [
-          "Creation of an assistant for generating innovative advertising campaign ideas",
-          "Development of an assistant for planning, updating, and evaluating projects",
-          "Implementation of features to maintain motivation and focus on achievements"
-        ],
-        tecnologias: ["HuggingFace", "Natural Language Processing", "Machine Learning", "Python"],
-        link: "https://huggingface.co/chat/assistants?user=Elelier",
-        link_u: "huggingface.co"
-      },
-      {
-        nombre: "Wonderlabs",
-        timeline: "2023-2024",
-        rol: "Senior Backend Developer",
-        image: wonderlabsImg,
-        descripcion: "I developed the backend infrastructure for a platform that generates personalized children's stories, integrating advanced AI for automatic story, image, and narration generation.",
-        logros: [
-          "Developed APIs to manage core workflows, including databases, story generation, images, and AI-driven storytelling",
-          "Configured and optimized a dynamic website using WIX for a seamless user experience",
-          "Implemented a customer service chatbot using advanced artificial intelligence"
-        ],
-        tecnologias: ["React", "Node.js", "API Development", "Generative AI", "WIX"],
-        link: "https://wonderlabs.studio",
-        link_u: "wonderlabs.studio"
-      },
-
-      {
-        nombre: "GoFarma",
-        timeline: "2016-2024",
-        rol: "Co-founder and Operations Director",
-        image: gofarmaImg,
-        descripcion: "Designed and implemented the company's operating model, achieving 99.8% inventory accuracy and competitive delivery times.",
-        logros: [
-          "99.8% inventory accuracy",
-          "2-minute order processing time",
-          "Optimization of local and national shipping"
-        ],
-        tecnologias: ["ERP Olimpo", "Process Automation", "Inventory Management"],
-        link: "http://www.gofarma.com",
-        link_u: "gofarma.com"
-      },
-      {
-        nombre: "Farmalisto",
-        timeline: "2022-2024",
-        rol: "Marketplace Sales Director",
-        image: farmalistoImg,
-        descripcion: "Managed the online presence across various marketplaces, increasing customer visibility and conversion.",
-        logros: [
-          "50% reduction in claims and cancellations",
-          "144% increase in sales",
-          "58% increase in average ticket"
-        ],
-        tecnologias: ["Mercado Libre", "Amazon", "Shopify", "NetSuite ERP", "AI for Customer Service"],
-        link: "https://www.farmalisto.com.mx/",
-        link_u: "farmalisto.com.mx"
-      },
-      {
-        nombre: "PepsiCo",
-        timeline: "2012-2016",
-        rol: "Productivity Projects Coordinator",
-        image: pepsicoImg,
-        descripcion: "Led improvement projects in 8 Gamesa-Quaker plants, optimizing processes and increasing efficiency.",
-        logros: [
-          "0.4% increase in raw material performance nationwide",
-          "Implementation of KPIs and capacity increase projects"
-        ],
-        tecnologias: ["SAP", "DMAIC Methodology", "Lean Six Sigma"]
-      }
-    ]
-  };
-
-  const ctaContent = {
-    es: {
-      title: '¿Te imaginas tu proyecto en este portafolio?',
-      description:
-        'Trabajemos juntos para diseñar una solución a medida, desde la estrategia hasta la implementación.',
-      primary: 'Hablemos de tu proyecto',
-      secondary: 'Conoce cómo trabajo'
-    },
-    en: {
-      title: 'Ready to see your project featured here?',
-      description:
-        'Let’s craft a tailored solution together—from strategic planning to hands-on implementation.',
-      primary: "Let's talk about your project",
-      secondary: 'See how I work'
+    if (!section || typeof window.IntersectionObserver === 'undefined' || typeof window.matchMedia !== 'function') {
+      document.body.classList.remove('career-section-in-view');
+      return undefined;
     }
-  };
 
-  const currentCta = ctaContent[language] || ctaContent.es;
+    const mobileQuery = window.matchMedia('(max-width: 768px)');
+
+    const syncFloatingControls = (isInView) => {
+      document.body.classList.toggle('career-section-in-view', mobileQuery.matches && isInView);
+    };
+
+    const observer = new window.IntersectionObserver(
+      ([entry]) => {
+        syncFloatingControls(entry.isIntersecting);
+      },
+      { threshold: 0.18 }
+    );
+
+    observer.observe(section);
+
+    const handleMediaChange = () => {
+      const sectionRect = section.getBoundingClientRect();
+      const isInView = sectionRect.top < window.innerHeight && sectionRect.bottom > 0;
+      syncFloatingControls(isInView);
+    };
+
+    if (mobileQuery.addEventListener) {
+      mobileQuery.addEventListener('change', handleMediaChange);
+    } else {
+      mobileQuery.addListener(handleMediaChange);
+    }
+
+    handleMediaChange();
+
+    return () => {
+      observer.disconnect();
+      if (mobileQuery.removeEventListener) {
+        mobileQuery.removeEventListener('change', handleMediaChange);
+      } else {
+        mobileQuery.removeListener(handleMediaChange);
+      }
+      document.body.classList.remove('career-section-in-view');
+    };
+  }, []);
+
+  const projects = useMemo(() => careerContent[currentLang] || careerContent.es, [currentLang]);
+  const currentCta = ctaContent[currentLang] || ctaContent.es;
+
+  const handleToggle = (index) => {
+    setActiveIndex((current) => (current === index ? null : index));
+  };
 
   const handleScrollToSection = (id) => {
     const section = document.getElementById(id);
@@ -244,81 +355,39 @@ const Portafolio = ({ style }) => {
 
   return (
     <section id="portafolio" className="portafolio" style={style}>
-      <h2>{currentLang === 'es' ? 'CARRERA PROFESIONAL' : 'PROFESSIONAL CAREER'}</h2>
-      <p className="introduccion">
-        {currentLang === 'es' 
-          ? 'Mi portafolio refleja una trayectoria diversa en tecnología y gestión empresarial. Cada proyecto representa un desafío único donde he aplicado mis conocimientos en desarrollo de software, inteligencia artificial y optimización de procesos.' 
-          : "My portfolio reflects a diverse background in technology and business management. Each project represents a unique challenge where I've applied my expertise in software development, artificial intelligence, and process optimization."}
-      </p>
-      <div className="timeline">
-        {(currentLang === 'es' ? proyectos.es : proyectos.en).map((proyecto, idx) => (
-          <article key={proyecto.nombre} className={idx % 2 === 0 ? 'left' : 'right'}>
-            <div
-              className={`content-wrapper ${activeIndex === idx ? 'expanded' : ''}`}
-              onClick={() => setActiveIndex(activeIndex === idx ? null : idx)}
-            >
-              <span className="year">{proyecto.timeline}</span>
-              <div className="banner-container">
-                <img 
-                  src={proyecto.image} 
-                  alt={proyecto.nombre || ''} 
-                  className="banner-image"
-                />
-                <div className="image-overlay"></div>
-              </div>
-              <div className="content">
-                <h3>{proyecto.nombre || ''}</h3>
-                <h4>{proyecto.rol || ''}</h4>
-                <p>{proyecto.descripcion || ''}</p>
-                {activeIndex === idx && (
-                  <div className="logros">
-                    <h5>{currentLang === 'es' ? 'Logros Destacados:' : 'Key Achievements:'}</h5>
-                    <ul>
-                      {proyecto.logros?.map((logro, logroIdx) => (
-                        <li key={logroIdx}>{logro}</li>
-                      ))}
-                    </ul>
-                    {proyecto.link && (
-                      <a 
-                        href={proyecto.link} 
-                        target="_blank" 
-                        rel="noopener noreferrer"
-                        className="proyecto-link"
-                      >
-                        {proyecto.link_u} →
-                      </a>
-                    )}
-                  </div>
-                )}
-              </div>
-              <div className="examples">
-                {proyecto.tecnologias?.map((tech, techIndex) => (
-                  <a 
-                    key={techIndex} 
-                    href={`#${tech.toLowerCase().replace(/\s+/g, '-')}`}
-                  >
-                    {tech}
-                  </a>
-                ))}
-              </div>
-            </div>
-          </article>
+      <div className="portafolio__heading">
+        <p className="portafolio__eyebrow">{currentLang === 'es' ? 'TRAYECTORIA' : 'CAREER'}</p>
+        <h2>{currentLang === 'es' ? 'Carrera profesional' : 'Professional career'}</h2>
+        <p className="introduccion">
+          {currentLang === 'es'
+            ? 'Una trayectoria construida entre operación, producto digital y soluciones que generan resultados reales.'
+            : 'A career built across operations, digital product and solutions that create measurable results.'}
+        </p>
+      </div>
+
+      <div className="timeline" role="list" aria-label={currentLang === 'es' ? 'Carrera profesional' : 'Professional career'}>
+        {projects.map((project, idx) => (
+          <div key={project.id} className="timeline__row" role="listitem">
+            <span className="timeline__node" aria-hidden="true" />
+            <CareerCard
+              entry={project}
+              index={idx}
+              language={currentLang}
+              isExpanded={activeIndex === idx}
+              onToggle={handleToggle}
+            />
+          </div>
         ))}
       </div>
+
       <div className="portafolio-cta">
         <h3>{currentCta.title}</h3>
         <p>{currentCta.description}</p>
         <div className="portafolio-cta-buttons">
-          <button
-            className="cta-button-primary"
-            onClick={() => handleScrollToSection('contacto')}
-          >
+          <button className="cta-button-primary" onClick={() => handleScrollToSection('contacto')}>
             {currentCta.primary}
           </button>
-          <button
-            className="cta-button-secondary"
-            onClick={() => handleScrollToSection('como-trabajo')}
-          >
+          <button className="cta-button-secondary" onClick={() => handleScrollToSection('como-trabajo')}>
             {currentCta.secondary}
           </button>
         </div>

--- a/my-app/src/components/Portafolio.test.js
+++ b/my-app/src/components/Portafolio.test.js
@@ -31,7 +31,12 @@ const renderPortafolio = (language = 'es') => {
   };
 };
 
-describe('Portafolio CTA', () => {
+const getCards = (container) => Array.from(container.querySelectorAll('[data-testid="career-card"]'));
+
+const getCard = (container, name) =>
+  getCards(container).find((card) => card.getAttribute('data-career-name') === name) || null;
+
+describe('Portafolio career timeline', () => {
   beforeEach(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
@@ -41,59 +46,144 @@ describe('Portafolio CTA', () => {
     document.body.innerHTML = '';
   });
 
-  it('points the secondary CTA to como-trabajo in Spanish', () => {
-    const target = document.createElement('section');
-    target.id = 'como-trabajo';
-    target.scrollIntoView = jest.fn();
-    document.body.appendChild(target);
-
+  it('shows only the three approved stages in Spanish and hides the retired ones', () => {
     const { container, cleanup } = renderPortafolio('es');
-    const secondaryCta = container.querySelector('.cta-button-secondary');
 
-    expect(secondaryCta.textContent).toContain('Conoce cómo trabajo');
-
-    act(() => {
-      secondaryCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    expect(target.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
+    expect(container.textContent).toContain('Carrera profesional');
+    expect(container.textContent).toContain('GoFarma + Farmalisto');
+    expect(container.textContent).toContain('CHUBB');
+    expect(container.textContent).toContain('Elier');
+    expect(container.textContent).not.toContain('Wonderlabs');
+    expect(container.textContent).not.toContain('PepsiCo');
+    expect(container.textContent).not.toContain('Freelancer');
+    expect(getCards(container)).toHaveLength(3);
 
     cleanup();
   });
 
-  it('renders the approved English secondary CTA copy', () => {
+  it('shows the three approved stages in the correct English order', () => {
     const { container, cleanup } = renderPortafolio('en');
 
-    expect(container.querySelector('.cta-button-secondary').textContent).toContain('See how I work');
+    expect(container.textContent).toContain('Professional career');
+    expect(container.textContent).toContain('GoFarma + Farmalisto');
+    expect(container.textContent).toContain('CHUBB');
+    expect(container.textContent).toContain('Elier');
+    expect(container.textContent).not.toContain('Wonderlabs');
+    expect(container.textContent).not.toContain('PepsiCo');
+    expect(container.textContent).not.toContain('Freelancer');
+
+    const cards = getCards(container);
+    expect(cards).toHaveLength(3);
+    expect(cards.map((card) => card.getAttribute('data-career-name'))).toEqual([
+      'GoFarma + Farmalisto',
+      'CHUBB',
+      'Elier'
+    ]);
 
     cleanup();
   });
 
-  it('labels the primary CTA as a contact action in both languages', () => {
-    const contacto = document.createElement('section');
-    contacto.id = 'contacto';
-    contacto.scrollIntoView = jest.fn();
-    document.body.appendChild(contacto);
+  it('starts every card collapsed and toggles details on click', () => {
+    const { container, cleanup } = renderPortafolio('es');
+    const card = getCard(container, 'GoFarma + Farmalisto');
 
-    const { container: esContainer, cleanup: cleanupEs } = renderPortafolio('es');
-    const esPrimaryCta = esContainer.querySelector('.cta-button-primary');
-    expect(esPrimaryCta.textContent).toContain('Hablemos de tu proyecto');
+    expect(card.getAttribute('aria-expanded')).toBe('false');
+    expect(card.textContent).toContain('Ver detalles ↓');
+    expect(card.textContent).not.toContain('Lo que moví');
+
     act(() => {
-      esPrimaryCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      card.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    expect(contacto.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
-    cleanupEs();
 
-    contacto.scrollIntoView.mockClear();
-    const { container: enContainer, cleanup: cleanupEn } = renderPortafolio('en');
-    const enPrimaryCta = enContainer.querySelector('.cta-button-primary');
-    expect(enPrimaryCta.textContent).toContain("Let's talk about your project");
+    expect(card.getAttribute('aria-expanded')).toBe('true');
+    expect(card.textContent).toContain('Lo que moví');
+    expect(card.textContent).toContain('Ocultar detalles ↑');
+
     act(() => {
-      enPrimaryCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      card.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    expect(contacto.scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' });
-    cleanupEn();
 
-    contacto.remove();
+    expect(card.getAttribute('aria-expanded')).toBe('false');
+    expect(card.textContent).not.toContain('Lo que moví');
+
+    cleanup();
+  });
+
+  it('expands with Enter and Space on keyboard', () => {
+    const { container, cleanup } = renderPortafolio('en');
+    const card = getCard(container, 'CHUBB');
+
+    expect(card.getAttribute('aria-expanded')).toBe('false');
+
+    act(() => {
+      card.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+
+    expect(card.getAttribute('aria-expanded')).toBe('true');
+    expect(card.textContent).toContain('What I moved');
+
+    act(() => {
+      card.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+    });
+
+    expect(card.getAttribute('aria-expanded')).toBe('false');
+
+    cleanup();
+  });
+
+  it('keeps external links outside the toggle behavior', () => {
+    const { container, cleanup } = renderPortafolio('es');
+    const card = getCard(container, 'Elier');
+    const links = Array.from(card.querySelectorAll('a'));
+
+    expect(links).toHaveLength(2);
+    expect(links[0].href).toBe('https://elelier.com/');
+    expect(links[1].href).toBe('https://linkedin.com/in/elier/');
+    expect(links[0].target).toBe('_blank');
+    expect(links[1].target).toBe('_blank');
+    expect(links[0].rel).toContain('noopener');
+    expect(links[1].rel).toContain('noopener');
+
+    act(() => {
+      links[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(card.getAttribute('aria-expanded')).toBe('false');
+
+    cleanup();
+  });
+
+  it('shows the approved Farmalisto metrics and the shared LinkedIn link', () => {
+    const { container, cleanup } = renderPortafolio('es');
+    const card = getCard(container, 'GoFarma + Farmalisto');
+    const farmalistoLink = card.querySelector('a');
+
+    expect(card.textContent).toContain('99.8% precisión de inventario');
+    expect(card.textContent).toContain('Pedidos en ~2 min');
+    expect(card.textContent).toContain('−50% reclamaciones y cancelaciones');
+    expect(card.textContent).toContain('+144% ventas');
+    expect(card.textContent).toContain('+58% ticket promedio');
+    expect(farmalistoLink.href).toBe('https://www.farmalisto.com.mx/');
+
+    cleanup();
+  });
+
+  it('shows the approved LinkedIn reuse on CHUBB and Elier', () => {
+    const { container, cleanup } = renderPortafolio('en');
+    const chubbCard = getCard(container, 'CHUBB');
+    const elierCard = getCard(container, 'Elier');
+    const chubbLink = chubbCard.querySelector('a');
+    const elierLinks = Array.from(elierCard.querySelectorAll('a'));
+
+    expect(chubbCard.textContent).toContain('Digital product');
+    expect(chubbCard.textContent).toContain('Operations');
+    expect(chubbLink.href).toBe('https://linkedin.com/in/elier/');
+    expect(chubbLink.textContent).toBe('View LinkedIn ↗');
+    expect(elierLinks.map((link) => link.href)).toEqual([
+      'https://elelier.com/',
+      'https://linkedin.com/in/elier/'
+    ]);
+
+    cleanup();
   });
 });

--- a/my-app/src/styles/components/ChatModal.css
+++ b/my-app/src/styles/components/ChatModal.css
@@ -364,6 +364,12 @@
     font-size: clamp(1.5rem, 2rem, 2.3rem) !important;
   }
 
+  body.career-section-in-view .chat-button {
+    opacity: 0 !important;
+    pointer-events: none !important;
+    transform: translateY(16px) scale(0.92) !important;
+  }
+
   .chat-content {
     flex: 1 !important;
     overflow-y: auto !important;

--- a/my-app/src/styles/components/FloatingButton.css
+++ b/my-app/src/styles/components/FloatingButton.css
@@ -50,4 +50,10 @@
     height: 3rem !important;
     font-size: 1.8rem !important;
   }
+
+  body.career-section-in-view .floating-button {
+    opacity: 0 !important;
+    pointer-events: none !important;
+    transform: translateY(16px) scale(0.92) !important;
+  }
 }

--- a/my-app/src/styles/components/Portafolio.css
+++ b/my-app/src/styles/components/Portafolio.css
@@ -4,12 +4,12 @@
 /* Contenedor principal del portafolio */
 .portafolio {
   position: relative;
-  padding: 60px 20px;
+  padding: 22px 20px;
+  scroll-margin-top: 60px;
   background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg-2)), var(--section-bg-end, var(--color-bg)));
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-height: 100vh;
   overflow: hidden;
 }
 
@@ -33,6 +33,40 @@
   top: 0;
   background-color: transparent;
   z-index: 100;
+}
+
+.portafolio__heading {
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto 12px;
+  text-align: center;
+}
+
+.portafolio__eyebrow {
+  margin: 0 0 6px;
+  color: var(--color-accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.portafolio__heading h2 {
+  position: static;
+  margin: 0;
+  background: none;
+  font-size: 2.25rem;
+  line-height: 1.05;
+}
+
+.introduccion {
+  font-size: 0.96rem;
+  text-align: center;
+  color: var(--color-text);
+  max-width: 740px;
+  line-height: 1.38;
+  padding: 0 20px;
+  margin: 8px auto 0;
 }
 
 .introduccion p {
@@ -183,40 +217,50 @@
 }
 
 .portafolio-cta {
-  margin-top: 60px;
-  max-width: 980px;
+  margin-top: 10px;
+  max-width: 900px;
   width: 100%;
   text-align: center;
   background: rgba(0, 0, 0, 0.25);
-  border-radius: 24px;
-  padding: 48px 32px;
+  border-radius: 18px;
+  padding: 14px 20px;
   box-shadow: 0 24px 48px rgba(0, 0, 0, 0.25);
   border: 1px solid rgba(255, 255, 255, 0.08);
   backdrop-filter: blur(8px);
 }
 
 .portafolio-cta h3 {
-  font-size: 2.2rem;
+  font-size: 1.18rem;
   color: var(--hero-title-color-2);
-  margin-bottom: 16px;
+  margin-bottom: 6px;
 }
 
 .portafolio-cta p {
   color: var(--color-text);
-  font-size: 1.15rem;
-  margin-bottom: 32px;
-  line-height: 1.7;
+  font-size: 0.88rem;
+  margin-bottom: 12px;
+  line-height: 1.35;
 }
 
 .portafolio-cta-buttons {
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 18px;
+  gap: 12px;
+}
+
+.portafolio-cta-buttons .cta-button-primary,
+.portafolio-cta-buttons .cta-button-secondary {
+  padding: 9px 20px;
+  font-size: 0.9rem;
 }
 
 /* Responsive */
 @media (max-width: 768px) {
+  .portafolio {
+    padding: 42px 14px;
+  }
+
   .proyectos-grid {
     grid-template-columns: 1fr;
     padding: 10px;
@@ -260,6 +304,7 @@
   .portafolio-cta {
     margin-top: 40px;
     padding: 36px 20px;
+    border-radius: 20px;
   }
 
   .portafolio-cta h3 {
@@ -268,6 +313,15 @@
 
   .portafolio-cta p {
     font-size: 1.05rem;
+  }
+
+  .portafolio__heading h2 {
+    font-size: 2.2rem;
+  }
+
+  .introduccion {
+    font-size: 1.05rem;
+    padding: 0 15px;
   }
 }
 

--- a/my-app/src/styles/components/Timeline.css
+++ b/my-app/src/styles/components/Timeline.css
@@ -1,443 +1,467 @@
-*, *:before, *:after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-  transition: inherit;
-}
-
-.timeline-container {
-  --j: calc(1 - var(--i));
-  --narr: 0;
-  --k: calc(1 - var(--narr));
-  font: 500 1em/1.25 koho, trebuchet ms, verdana, sans-serif;
-  transition: 0.3s;
-  margin: 2rem auto;
-  padding: 1rem;
-  max-width: 100%;
-  overflow: hidden;
-}
-
 .timeline {
-  position: relative;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px;
-}
-
-/* Línea central */
-.timeline::after {
-  content: '';
-  position: absolute;
-  width: 3px;
-  background: linear-gradient(180deg, var(--hero-title-color), var(--hero-title-color-2));
-  top: 300px;
-  bottom: 280px;
-  left: 50%;
-  transform: translateX(-50%);
-  border-radius: 1px;
-  z-index: 0;
-}
-
-.timeline article {
-  position: relative;
-  width: calc(50% - 40px);
-  margin: 2rem 0;
-  opacity: 0;
-  animation: fadeIn 0.5s ease forwards;
-  z-index: 2;
-}
-
-/* Posicionamiento alternado */
-.timeline article:nth-child(odd) {
-  left: 0;
-}
-
-.timeline article:nth-child(even) {
-  left: 50%;
-  margin-left: 40px;
-}
-
-/* Ajuste de entrelazado a partir del segundo elemento */
-.timeline article:not(:first-child) {
-  margin-top: -160px;
-}
-
-/* Círculo en la línea temporal */
-.timeline article::before {
-  content: '';
-  position: absolute;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: var(--color-accent);
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1;
-  box-shadow: 0 0 0 6px var(--color-bg-2),
-              0 0 20px var(--color-accent);
-}
-
-.timeline article:nth-child(odd)::before {
-  right: -50px;
-}
-
-.timeline article:nth-child(even)::before {
-  left: -50px;
-}
-
-@media (max-width: 768px) {
-  .timeline::after {
-    left: 30px;
-    top: 260px;
-    bottom: 275px;
-
-  }
-
-  .timeline article {
-    width: calc(100% - 80px) !important;
-    margin-left: 60px !important;
-    padding: 0 20px 0 0 !important;
-    left: 0 !important;
-    margin-top: 0 !important;
-    margin-bottom: 2rem;
-  }
-
-  .timeline article::before {
-    left: -60px !important;
-    right: auto !important;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-
-  .timeline article .content-wrapper {
-    width: 100%;
-  }
-}
-
-.timeline article:hover::before {
-  transform: translateY(-50%) scale(1.3);
-  transition: all 0.3s ease-in-out;
-}
-
-.timeline article .content-wrapper {
-  position: relative;
-  z-index: 2;
-  background: linear-gradient(145deg, var(--color-bg-solid), var(--color-bg));
-  border-radius: 15px;
-  overflow: hidden;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
-  cursor: pointer;
-  min-height: 250px;
-}
-
-.timeline article .content-wrapper:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
-  background: linear-gradient(145deg, var(--color-bg-3), var(--color-bg-solid));
-}
-
-/* Banner de imagen */
-.timeline article .banner-image {
-  width: 101%;
-  height: 200px;
-  object-fit: cover;
-  transition: transform 0.3s ease;
-}
-
-.timeline article .content-wrapper:hover .banner-image {
-  transform: scale(1.05);
-}
-
-.timeline article .image-overlay {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 50%;
-  pointer-events: none;
-}
-
-/* Header con el año */
-.timeline article .year {
+  --timeline-line-offset: 56px;
   position: relative;
   width: 100%;
-  padding: 1rem;
-  background: linear-gradient(145deg, var(--color-bg-solid), var(--color-bg));
-  color: var(--color-bg);
-  text-align: right;
-  font-size: 1.5rem;
-  font-weight: 700;
-  letter-spacing: 1px;
-  transition: all 0.3s ease;
-  display: flex;
-  justify-content: flex-end;
-  color: var(--color-accent);
-  align-items: center;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 22px 0 0;
 }
 
-.timeline article .year::before {
+.timeline::before {
   content: '';
   position: absolute;
   top: 0;
-  left: 0;
+  bottom: 0;
+  left: var(--timeline-line-offset);
+  width: 3px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, var(--hero-title-color), var(--color-accent));
+  opacity: 0.9;
+}
+
+.timeline__row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  align-items: start;
+  column-gap: 0;
+  margin-bottom: 22px;
+}
+
+.timeline__node {
+  position: relative;
+  justify-self: center;
+  width: 18px;
+  height: 18px;
+  margin-top: 56px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  box-shadow:
+    0 0 0 6px color-mix(in srgb, var(--color-bg-solid) 88%, transparent),
+    0 0 22px rgba(123, 207, 248, 0.55);
+  transition:
+    transform 0.28s ease,
+    box-shadow 0.28s ease,
+    background 0.28s ease;
+}
+
+.timeline__row:hover .timeline__node,
+.timeline__row:focus-within .timeline__node {
+  transform: scale(1.14);
+  box-shadow:
+    0 0 0 7px color-mix(in srgb, var(--color-bg-solid) 84%, transparent),
+    0 0 28px rgba(123, 207, 248, 0.78);
+}
+
+.timeline-card {
+  background: linear-gradient(145deg, var(--color-bg-solid), var(--color-bg));
+  border: 1px solid rgba(123, 207, 248, 0.12);
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
+  cursor: pointer;
+  transition:
+    transform 0.28s ease,
+    box-shadow 0.28s ease,
+    border-color 0.28s ease,
+    background 0.28s ease;
+  text-align: left;
+  width: 100%;
+  color: inherit;
+}
+
+.timeline-card:hover,
+.timeline-card:focus-visible {
+  transform: translateY(-5px);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.2);
+  border-color: rgba(123, 207, 248, 0.35);
+  outline: none;
+}
+
+.timeline-card:focus-visible {
+  box-shadow:
+    0 18px 36px rgba(0, 0, 0, 0.2),
+    0 0 0 3px rgba(123, 207, 248, 0.28);
+}
+
+.timeline-card--expanded {
+  border-color: rgba(123, 207, 248, 0.28);
+}
+
+.timeline-card__period {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: 56px;
+  padding: 0 22px;
+  color: var(--color-accent);
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.03), transparent);
+}
+
+.timeline-card__banner {
+  position: relative;
+  height: 104px;
+  overflow: hidden;
+}
+
+.timeline-card__image {
+  display: block;
   width: 100%;
   height: 100%;
-  background: linear-gradient(to right, transparent, rgba(255, 255, 255, 0.1));
-  transform: translateX(-100%);
-  transition: transform 0.5s ease;
+  object-fit: cover;
+  transform: scale(1);
+  transition: transform 0.32s ease;
 }
 
-.timeline article:hover .year::before {
-  transform: translateX(0);
-}
-
-.timeline article .content {
-  padding: 1.5rem;
-  padding-top: 0.5rem;
-}
-
-/* Contenido */
-.timeline article .content {
-  padding: 20px;
-  transition: all 0.3s ease;
-}
-
-.timeline article h3 {
-  margin: 0 0 0.5rem;
-  font-size: 1.25rem;
-  color: var(--color-accent);
-}
-
-.timeline article h4 {
-  margin: 0 0 1rem;
-  font-size: 1rem;
-  color: var(--color-accent);
-  font-weight: 500;
-}
-
-.timeline article p {
-  margin: 0;
-  color: var(--color-text);
-  line-height: 1.6;
-}
-
-.timeline article .logros {
-  margin-top: 1.5rem;
-  opacity: 0;
-  max-height: 0;
-  overflow: hidden;
-  transition: all 0.3s ease;
-}
-
-.timeline article .content-wrapper.expanded .logros {
-  opacity: 1;
-  max-height: 1000px;
-  margin-bottom: 1rem;
-}
-
-.timeline article .logros h5 {
-  color: var(--color-accent);
-  font-size: 1.1rem;
-  margin-bottom: 0.8rem;
-}
-
-.timeline article .logros ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  margin-bottom: 1rem;
-}
-
-.timeline article .logros li {
-  color: var(--color-text);
-  margin-bottom: 0.5rem;
-  padding-left: 1.2rem;
-  position: relative;
-  line-height: 1.4;
-}
-
-.timeline article .logros li::before {
-  content: '•';
-  color: var(--color-accent);
-  position: absolute;
-  left: 0;
-  font-weight: bold;
-}
-
-@keyframes gradientBG {
-  0% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-  100% {
-    background-position: 0% 50%;
-  }
-}
-
-.timeline article .proyecto-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.8rem;
-  background: linear-gradient(135deg, #a80c9b, #7bcff8, #00cc99);
-  background-size: 300% 300%;
-  animation: gradientBG 10s ease infinite;
-  color: white;
-  padding: 10px 20px;
-  font-size: 1rem;
-  border-radius: 20px;
-  text-decoration: none;
-  font-weight: bold;
-  margin-top: 1.5rem;
-  transition: all 0.3s ease;
-  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-  z-index: 2;
-  position: relative;
-  isolation: isolate;
-}
-
-.timeline article .proyecto-link::before {
-  content: '';
+.timeline-card__overlay {
   position: absolute;
   inset: 0;
-  background: rgba(255, 255, 255, 0.15);
-  border-radius: inherit;
-  z-index: -1;
+  background: linear-gradient(180deg, rgba(3, 10, 20, 0.08) 0%, rgba(3, 10, 20, 0.46) 100%);
+  transition: opacity 0.28s ease;
 }
 
-.timeline article .proyecto-link:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 6px 8px rgba(0,0,0,0.3);
-  text-shadow: 0 2px 4px rgba(0,0,0,0.3), 0 1px 2px rgba(0,0,0,0.2);
-  animation: gradientBG 18s ease infinite;
+.timeline-card:hover .timeline-card__image,
+.timeline-card:focus-visible .timeline-card__image,
+.timeline-card--expanded .timeline-card__image {
+  transform: scale(1.04);
 }
 
-.timeline article .proyecto-link:hover::before {
-  background: rgba(255, 255, 255, 0.2);
+.timeline-card:hover .timeline-card__overlay,
+.timeline-card:focus-visible .timeline-card__overlay,
+.timeline-card--expanded .timeline-card__overlay {
+  opacity: 0.9;
 }
 
-.timeline article .proyecto-link:active {
-  transform: scale(0.95);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3), inset 0 -1px 2px rgba(0, 0, 0, 0.2);
-  animation: none;
-  background: linear-gradient(135deg, #8a0a7f, #65acd0, #00a37a);
+.timeline-card__body {
+  padding: 15px;
 }
 
-.timeline article .examples {
-  padding: 0 20px 20px;
-  opacity: 0;
-  max-height: 0;
-  overflow: hidden;
-  transition: all 0.3s ease;
-  margin-top: 10px;
+.timeline-card__identity h3 {
+  margin: 0;
+  color: var(--hero-title-color-2);
+  font-size: 1.28rem;
+  line-height: 1.2;
+}
+
+.timeline-card__identity h4 {
+  margin: 7px 0 8px;
+  color: var(--color-accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.timeline-card__identity p {
+  margin: 0;
+  color: var(--color-text);
+  font-size: 0.86rem;
+  line-height: 1.36;
+}
+
+.timeline-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 11px;
+}
+
+.timeline-card__chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 25px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(123, 207, 248, 0.22);
+  background: rgba(123, 207, 248, 0.08);
+  color: var(--color-text);
+  font-size: 0.74rem;
+  line-height: 1;
+  transition:
+    transform 0.22s ease,
+    border-color 0.22s ease,
+    background 0.22s ease;
+}
+
+.timeline-card:hover .timeline-card__chip,
+.timeline-card:focus-visible .timeline-card__chip {
+  border-color: rgba(123, 207, 248, 0.45);
+  background: rgba(123, 207, 248, 0.12);
+}
+
+.timeline-card__details {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(123, 207, 248, 0.15);
+}
+
+.timeline-card__details h5 {
+  margin: 0 0 8px;
+  color: var(--hero-title-color-2);
+  font-size: 0.92rem;
+  font-weight: 700;
+}
+
+.timeline-card__details ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.timeline-card__details li {
   position: relative;
-  z-index: 2;
-  border-radius: 0 0 15px 15px;
+  margin: 0 0 7px;
+  padding-left: 15px;
+  color: var(--color-text);
+  font-size: 0.84rem;
+  line-height: 1.35;
 }
 
-.timeline article .content-wrapper.expanded .examples {
-  opacity: 1;
-  max-height: 1000px;
-  padding-bottom: 30px;
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
-}
-
-.timeline article .examples a {
-  display: inline-block;
-  margin: 5px 10px;
-  padding: 5px 10px;
+.timeline-card__details li::before {
+  content: '';
+  position: absolute;
+  top: 0.68em;
+  left: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
   background: var(--color-accent);
-  border-radius: 15px;
-  color: var(--color-bg-solid);
+  box-shadow: 0 0 0 4px rgba(123, 207, 248, 0.08);
+}
+
+.timeline-card__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 11px;
+}
+
+.timeline-card__links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(123, 207, 248, 0.18), rgba(0, 204, 153, 0.18));
+  border: 1px solid rgba(123, 207, 248, 0.24);
+  color: var(--hero-title-color-2);
+  font-size: 0.78rem;
+  font-weight: 700;
   text-decoration: none;
-  transition: all 0.3s ease;
-  z-index: 3;
+  transition:
+    transform 0.22s ease,
+    border-color 0.22s ease,
+    background 0.22s ease;
 }
 
-.timeline article .examples a:hover {
-  background: var(--color-accent-hover);
+.timeline-card__links a:hover,
+.timeline-card__links a:focus-visible {
   transform: translateY(-2px);
+  border-color: rgba(123, 207, 248, 0.46);
+  background: linear-gradient(135deg, rgba(123, 207, 248, 0.24), rgba(0, 204, 153, 0.24));
+  outline: none;
 }
 
-/* Animación de entrada */
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+.timeline-card__toggle {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 9px;
+  color: var(--color-accent);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
-/* Responsive */
-@media (max-width: 1024px) {
-  .timeline article .banner-image {
-    height: 200px;
+@media (min-width: 1024px) {
+  .timeline {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 18px;
+    padding-top: 32px;
   }
-}
 
-@media (max-width: 860px) {
-  .timeline article .banner-image {
-    height: 160px;
+  .timeline::before {
+    top: 21px;
+    bottom: auto;
+    left: calc(16.666% + 9px);
+    right: calc(16.666% + 9px);
+    width: auto;
+    height: 3px;
+    background: linear-gradient(90deg, var(--hero-title-color), var(--color-accent));
+  }
+
+  .timeline__row {
+    display: flex;
+    min-width: 0;
+    margin-bottom: 0;
+  }
+
+  .timeline__node {
+    position: absolute;
+    top: -20px;
+    left: 50%;
+    z-index: 2;
+    margin-top: 0;
+    transform: translateX(-50%);
+  }
+
+  .timeline__row:hover .timeline__node,
+  .timeline__row:focus-within .timeline__node {
+    transform: translateX(-50%) scale(1.14);
+  }
+
+  .timeline-card {
+    display: flex;
+    flex-direction: column;
+    min-height: 360px;
+  }
+
+  .timeline-card__period {
+    min-height: 36px;
+    padding: 0 16px;
+    font-size: 0.72rem;
+  }
+
+  .timeline-card__body {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+  }
+
+  .timeline-card__identity {
+    min-height: 100px;
+  }
+
+  .timeline-card__chips {
+    min-height: 56px;
+  }
+
+  .timeline-card__links {
+    margin-top: auto;
+    padding-top: 12px;
+  }
+
+  .timeline-card__toggle {
+    margin-top: 10px;
+  }
+
+  .timeline-card--expanded .timeline-card__banner {
+    height: 88px;
+  }
+
+  .timeline-card--expanded .timeline-card__details {
+    margin-top: 8px;
+    padding-top: 8px;
+  }
+
+  .timeline-card--expanded .timeline-card__details h5 {
+    margin-bottom: 5px;
+    font-size: 0.84rem;
+  }
+
+  .timeline-card--expanded .timeline-card__details li {
+    margin-bottom: 4px;
+    padding-left: 13px;
+    font-size: 0.74rem;
+    line-height: 1.2;
+  }
+
+  .timeline-card--expanded .timeline-card__details li::before {
+    top: 0.52em;
+    width: 5px;
+    height: 5px;
+    box-shadow: 0 0 0 3px rgba(123, 207, 248, 0.08);
   }
 }
 
 @media (max-width: 768px) {
-
-
-  .timeline article {
-    width: calc(100% - 30px) !important;
-    margin-left: 60px !important;
-    padding: 0 20px 0 0 !important;
-    left: 0 !important;
-    margin-top: 0 !important;
-    margin-bottom: 2rem;
+  .timeline {
+    --timeline-line-offset: 28px;
+    padding-top: 20px;
   }
 
-  .timeline article::before {
-    left: -60px !important;
-    right: auto !important;
-    top: 50%;
-    transform: translateY(-50%);
+  .timeline::before {
+    left: var(--timeline-line-offset);
   }
 
-  .timeline article .year {
-    right: 0px !important;
-    left: auto !important;
+  .timeline__row {
+    grid-template-columns: 28px minmax(0, 1fr);
+    margin-bottom: 18px;
   }
-}
 
-@media (max-width: 600px) {
-  .timeline article .banner-image {
-    height: 190px;
+  .timeline__node {
+    width: 16px;
+    height: 16px;
+    margin-top: 52px;
+  }
+
+  .timeline-card__period {
+    min-height: 52px;
+    padding: 0 18px;
+    font-size: 0.92rem;
+  }
+
+  .timeline-card__body {
+    padding: 18px;
+  }
+
+  .timeline-card__banner {
+    height: 128px;
+  }
+
+  .timeline-card__identity h3 {
+    font-size: 1.32rem;
+  }
+
+  .timeline-card__identity h4 {
+    margin-top: 8px;
   }
 }
 
 @media (max-width: 480px) {
-  .timeline article .banner-image {
-    height: 130px;
+  .timeline-card__banner {
+    height: 116px;
   }
 
-  .timeline article .content {
-    padding: 1rem;
+  .timeline-card__body {
+    padding: 16px;
+  }
+
+  .timeline-card__chips {
+    gap: 8px;
+  }
+
+  .timeline-card__chip {
+    font-size: 0.85rem;
+  }
+
+  .timeline-card__links {
+    gap: 10px;
   }
 }
 
-@media (max-width: 360px) {
-
-
-  .timeline article .banner-image {
-    height: 120px;
+@media (prefers-reduced-motion: reduce) {
+  .timeline-card,
+  .timeline-card__image,
+  .timeline-card__overlay,
+  .timeline-card__chip,
+  .timeline-card__links a,
+  .timeline__node {
+    transition: none !important;
+    animation: none !important;
   }
-}
 
-
-@media (max-width: 12em) {
-  .timeline-container {
-    font-size: 0.75em;
+  .timeline-card:hover,
+  .timeline-card:focus-visible,
+  .timeline-card:hover .timeline-card__image,
+  .timeline-card:focus-visible .timeline-card__image,
+  .timeline-card--expanded .timeline-card__image,
+  .timeline__row:hover .timeline__node,
+  .timeline__row:focus-within .timeline__node {
+    transform: none !important;
   }
 }

--- a/my-app/src/styles/index.css
+++ b/my-app/src/styles/index.css
@@ -215,6 +215,12 @@ a {
     transform: translate(8px, -1.5px);
     animation: blink 2s infinite;
   }
+
+  body.career-section-in-view [data-chatbot-chat-widget-button] {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(16px) scale(0.92);
+  }
 }
 
 /* Definición de la animación parpadeante */


### PR DESCRIPTION
## Summary
- Redesigns the Career section into three approved stages: GoFarma + Farmalisto, CHUBB, and Elier.
- Uses a horizontal three-card timeline on desktop and a vertical stacked timeline on mobile.
- Preserves current assets, hover/zoom/glow behavior, bilingual content, keyboard expansion, and external links.
- Hides floating controls while the Career section is visible on mobile so they do not cover cards, banners, links, or expanded content.
- Removes viewport-fixed height constraints from Career so expanded cards grow naturally.

## Validation
- npm test -- --runInBand --watchAll=false
- npm run build
- git diff --check
- Browser QA on http://127.0.0.1:3000/#portafolio for desktop 1440x900 and mobile 390x844, closed and expanded states.

## Notes
- The build generates src/config/hashedPasscodes.js; it was restored and is not included in this PR.