### PR TITLE
Iteration 11: a11y base and head coherence

### DIFF
--- a/my-app/public/index.html
+++ b/my-app/public/index.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
-<html lang="en" id="html-lang">
+<html lang="es-MX" id="html-lang">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Elier Loya: Especialista en Optimización de Operaciones, Transformación Digital, E-Commerce, Soluciones AI, Logística y Estrategias Basadas en Datos. Transformando operaciones para un crecimiento exponencial.">
+    <meta name="description" content="Transformo procesos complicados en soluciones que realmente funcionan. Especialista en operaciones, producto digital e IA aplicada.">
     <meta name="keywords" content="Optimización de Operaciones, Transformación Digital, E-Commerce, Soluciones AI, Logística, Estrategias Basadas en Datos, Consultoría Empresarial">
     <link rel="icon" href="https://github.com/elelier/portafolio-personal/blob/61fcfbdd536bbd2099010548f084168cb9bd8483/my-app/public/favicon.ico" />
-    <meta property="og:title" content="Elier Loya - Ingeniero en Transformación Digital y Optimización de Operaciones">
-    <meta property="og:description" content="Experto en transformación digital, e-commerce, soluciones AI y optimización de operaciones. Impulsa tu negocio con estrategias innovadoras y eficientes.">
+    <meta property="og:title" content="Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya">
+    <meta property="og:description" content="Transformo procesos complicados en soluciones que realmente funcionan. Especialista en operaciones, producto digital e IA aplicada.">
     <meta property="og:image" content="https://elelier.com/static/media/eleliercom.ced5bb90383175580555.png">
     <meta property="og:image:alt" content="Iagen alusiva a la página de El Elier Loya y los servicios de transformación digital, e-commerce, soluciones AI y optimización de operaciones.">
     <meta property="og:updated_time" content="1740272295">
-    <meta property="og:url" content="https://www.elelier.com">
+    <meta property="og:url" content="https://elelier.com/">
     <meta property="og:type" content="website">
 
     <!-- Schema.org JSON-LD -->
@@ -21,8 +21,8 @@
       "@type": ["WebSite", "Person"],
       "name": "Elier Loya",
       "alternateName": "Elier Loya Portfolio",
-      "url": "https://elelier.github.io/portafolio-personal/",
-      "image": "https://elelier.github.io/portafolio-personal/static/media/eleliercom.ced5bb90383175580555.png",
+      "url": "https://elelier.com/",
+      "image": "https://elelier.com/static/media/eleliercom.ced5bb90383175580555.png",
       "jobTitle": "Especialista en Transformación Digital",
       "alumniOf": {
         "@type": "EducationalOrganization",
@@ -40,7 +40,7 @@
     }
     </script>
 
-    <title>Elier Loya - Transformación Digital | Optimización de Operaciones</title>
+    <title>Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <script src="https://cdn.jsdelivr.net/npm/typed.js@2.0.12" defer></script>
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -31,7 +31,7 @@ import PrivacyPolicy from './pages/PrivacyPolicy';
 import TermsOfService from './pages/TermsOfService';
 import AionLabs from './components/AionLabs';
 import { initializeTheme } from './components/utils/themeUtils';
-import { loadExternalScripts } from './components/utils/generalUtils';
+import { getMotionAwareScrollBehavior, loadExternalScripts } from './components/utils/generalUtils';
 import './utils/testGemini';
 
 if (process.env.NODE_ENV === 'development') {
@@ -71,7 +71,7 @@ function App({ initialLanguage }) {
   }, [initialLanguage]);
 
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
+    window.scrollTo({ top: 0, behavior: getMotionAwareScrollBehavior() });
   };
 
   return (
@@ -82,8 +82,8 @@ function App({ initialLanguage }) {
             <div className="App">
               <SettingsMenu />
               <SEO
-                title="Elier Loya - Transformando Negocios con Tecnología e Innovación"
-                description="Portafolio de Elier Loya, especialista en transformación digital, e-commerce y optimización de operaciones."
+                title="Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya"
+                description="Transformo procesos complicados en soluciones que realmente funcionan. Especialista en operaciones, producto digital e IA aplicada."
               />
               <Navegacion />
               <Suspense fallback={<div>Loading...</div>}>

--- a/my-app/src/components/ArsenalHabilidades.js
+++ b/my-app/src/components/ArsenalHabilidades.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { LazyLoadImage } from 'react-lazy-load-image-component';
 import '../styles/components/Habilidades.css';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import strategic_vision from '../assets/images/skills/strategic_vision.png';
 import team_leadership from '../assets/images/skills/team_leadership.png';
 import tech_integration from '../assets/images/skills/tech_integration.png';
@@ -185,7 +186,7 @@ function ArsenalHabilidades({ style }) {
   const scrollToSection = (id) => {
     const section = document.getElementById(id);
     if (section) {
-      section.scrollIntoView({ behavior: 'smooth' });
+      scrollIntoViewWithMotionPreference(section);
     }
   };
 

--- a/my-app/src/components/CasosEstudio.js
+++ b/my-app/src/components/CasosEstudio.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import '../styles/components/CasosEstudio.css';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import arqidiaPreview from '../assets/images/casos-arqidia-preview.jpg';
 import oneClicTripPreview from '../assets/images/casos-oneclictrip-preview.jpg';
 
@@ -82,7 +83,7 @@ function CasosEstudio({ style }) {
   const t = content[language] || content.es;
 
   const scrollToContacto = () => {
-    document.getElementById('contacto')?.scrollIntoView({ behavior: 'smooth' });
+    scrollIntoViewWithMotionPreference(document.getElementById('contacto'));
   };
 
   return (

--- a/my-app/src/components/ChatModal.js
+++ b/my-app/src/components/ChatModal.js
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import { FaRocket, FaUserAlt, FaCogs, FaCode, FaEnvelope, FaTimes, FaPaperPlane, FaRobot } from 'react-icons/fa';
 import { SystemMessage, UserMessage } from '../utils/MessageSystem';
 import { getBenefitResponse } from '../utils/benefitResponses';
@@ -175,12 +176,12 @@ const ChatModal = () => {
 
   const toggleChat = () => {
     if (!isOpen) {
-      // Si hay histórico, hacemos scroll al final después de que se abra
-      if (messages.length > 0) {
-        setTimeout(() => {
-          messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-        }, 100);
-      }
+        // Si hay histórico, hacemos scroll al final después de que se abra
+        if (messages.length > 0) {
+          setTimeout(() => {
+            scrollIntoViewWithMotionPreference(messagesEndRef.current);
+          }, 100);
+        }
     }
     setIsOpen(!isOpen);
   };
@@ -246,8 +247,7 @@ const ChatModal = () => {
 
   const scrollToBottom = () => {
     if (messagesEndRef.current) {
-      messagesEndRef.current.scrollIntoView({ 
-        behavior: 'smooth',
+      scrollIntoViewWithMotionPreference(messagesEndRef.current, {
         block: 'end',
         inline: 'nearest'
       });
@@ -260,7 +260,7 @@ const ChatModal = () => {
 
   useEffect(() => {
     if (isOpen && messages.length > 0) {
-      messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+      scrollIntoViewWithMotionPreference(messagesEndRef.current);
     }
   }, [isOpen, messages]);
 

--- a/my-app/src/components/ClientSpace.jsx
+++ b/my-app/src/components/ClientSpace.jsx
@@ -9,6 +9,7 @@ import clientAuthService from '../services/clientAuthService';
 import { hashedPasscodes } from '../config/hashedPasscodes';
 import '../styles/components/ClientSpace.css';
 import { useLanguage } from '../contexts/LanguageContext';
+import { getMotionAwareScrollBehavior } from './utils/generalUtils';
 
 const ClientSpace = () => {
   const { token } = useParams();
@@ -227,7 +228,7 @@ const ClientSpace = () => {
 
       window.scrollTo({
         top: offsetPosition,
-        behavior: 'smooth'
+        behavior: getMotionAwareScrollBehavior()
       });
     }
   };

--- a/my-app/src/components/Contacto.js
+++ b/my-app/src/components/Contacto.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useLocation } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
+import { usePrefersReducedMotion } from './utils/generalUtils';
 import perfilImg from '../assets/images/profile-picture-elier2.png';
 import '../styles/components/Contacto.css';
 
@@ -66,6 +67,8 @@ function Contacto({ style }) {
   const { language } = useLanguage();
   const t = texts[language] || texts.en;
   const location = useLocation();
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const AnimatedSection = prefersReducedMotion ? 'section' : motion.section;
 
   const [name, setName] = useState('');
   const [mail, setMail] = useState('');
@@ -117,13 +120,17 @@ function Contacto({ style }) {
   const feedbackClassName = feedback.type ? `contacto-feedback contacto-feedback--${feedback.type}` : 'contacto-feedback';
 
   return (
-    <motion.section
+    <AnimatedSection
       id="contacto"
       className="contacto"
       style={{ scrollMarginTop: '96px', ...style }}
-      initial={{ opacity: 0, y: 32 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5, ease: 'easeOut' }}
+      {...(prefersReducedMotion
+        ? {}
+        : {
+            initial: { opacity: 0, y: 32 },
+            animate: { opacity: 1, y: 0 },
+            transition: { duration: 0.5, ease: 'easeOut' }
+          })}
     >
       <div className="contacto-shell">
         <div className="contacto-heading">
@@ -247,7 +254,7 @@ function Contacto({ style }) {
           </form>
         </div>
       </div>
-    </motion.section>
+    </AnimatedSection>
   );
 }
 

--- a/my-app/src/components/Footer.js
+++ b/my-app/src/components/Footer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import '../styles/components/Footer.css';
 
 function Footer() {
@@ -34,7 +35,7 @@ function Footer() {
   const handleScrollToElement = (id) => {
     const element = document.getElementById(id);
     if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
+      scrollIntoViewWithMotionPreference(element);
     }
   };
 

--- a/my-app/src/components/HeroBanner.js
+++ b/my-app/src/components/HeroBanner.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useContext } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import { ThemeContext } from '../contexts/ThemeContext';
+import { usePrefersReducedMotion, scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import heroPortrait from '../assets/images/profile-picture-elier2.png';
 import '../styles/components/HeroBanner.css';
 
@@ -10,6 +11,7 @@ const DynamicHeroBanner = ({ style }) => {
   const [scrollPosition, setScrollPosition] = useState(0);
   const { language } = useLanguage();
   const { currentTheme } = useContext(ThemeContext);
+  const prefersReducedMotion = usePrefersReducedMotion();
 
   const heroContent = useMemo(() => ({
     es: [
@@ -57,6 +59,10 @@ const DynamicHeroBanner = ({ style }) => {
   }, []);
 
   useEffect(() => {
+    if (prefersReducedMotion) {
+      return undefined;
+    }
+
     const canvas = document.getElementById('star-canvas');
     if (!canvas) return;
 
@@ -101,12 +107,12 @@ const DynamicHeroBanner = ({ style }) => {
       window.removeEventListener('resize', resizeCanvas);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
     };
-  }, [currentTheme]);
+  }, [currentTheme, prefersReducedMotion]);
 
   const getFadeClass = useCallback(() => (scrollPosition > 100 ? 'fade-out' : 'fade-in'), [scrollPosition]);
 
   const scrollToSection = useCallback((id) => {
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
+    scrollIntoViewWithMotionPreference(document.getElementById(id));
   }, []);
 
   return (
@@ -126,8 +132,8 @@ const DynamicHeroBanner = ({ style }) => {
           <span className="hero-eyebrow">
             {language === 'es' ? 'Producto digital · Operaciones · IA aplicada' : 'Digital product · Operations · Applied AI'}
           </span>
-          <h2 className="hero-title shiny">{currentContent?.title}</h2>
-          <h3 className="hero-subtitle">{currentContent?.subtitle}</h3>
+          <h1 className="hero-title shiny">{currentContent?.title}</h1>
+          <p className="hero-subtitle">{currentContent?.subtitle}</p>
           <p className="hero-description">{currentContent?.description}</p>
           <div className="hero-actions" aria-label="Acciones principales">
             <button className="hero-button" onClick={() => scrollToSection('contacto')}>

--- a/my-app/src/components/HeroBanner.test.js
+++ b/my-app/src/components/HeroBanner.test.js
@@ -35,6 +35,17 @@ describe('HeroBanner', () => {
     jest.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
       clearRect: jest.fn()
     });
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: query.includes('prefers-reduced-motion') ? false : false,
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      onchange: null,
+      dispatchEvent: jest.fn()
+    }));
+    window.requestAnimationFrame = jest.fn();
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
@@ -88,6 +99,21 @@ describe('HeroBanner', () => {
     cleanup();
   });
 
+  it('renders a single H1 in the hero and keeps the credential as supporting text', () => {
+    const { container, cleanup } = renderHero('es');
+
+    expect(container.querySelectorAll('h1')).toHaveLength(1);
+    expect(container.querySelector('h1.hero-title.shiny')?.textContent).toBe(
+      'Transformo procesos complicados en soluciones que realmente funcionan.'
+    );
+    expect(container.querySelector('h2.hero-title')).toBeNull();
+    expect(container.querySelector('h3.hero-subtitle')).toBeNull();
+    expect(container.querySelectorAll('h3').length).toBe(0);
+    expect(container.textContent).toContain('Ex-COO de GoFarma y Digital Product Owner en CHUBB.');
+
+    cleanup();
+  });
+
   it('uses the approved English hero positioning and CTA copy', () => {
     const soluciones = document.createElement('section');
     soluciones.id = 'soluciones';
@@ -105,6 +131,37 @@ describe('HeroBanner', () => {
     expect(container.querySelector('.hero-button-secondary').textContent).toContain('Explore real projects');
     expect(container.querySelector('.scroll-indicator').textContent).toContain('See solutions');
     expect(container.innerHTML).not.toContain('calendly.com');
+
+    cleanup();
+  });
+
+  it('respects reduced motion by skipping the star canvas animation and smooth scrolling', () => {
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      onchange: null,
+      dispatchEvent: jest.fn()
+    }));
+
+    const contacto = document.createElement('section');
+    contacto.id = 'contacto';
+    contacto.scrollIntoView = jest.fn();
+    document.body.appendChild(contacto);
+
+    const { container, cleanup } = renderHero('es');
+
+    expect(window.requestAnimationFrame).not.toHaveBeenCalled();
+
+    const primaryCta = container.querySelector('.hero-button');
+    act(() => {
+      primaryCta.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(contacto.scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto' });
 
     cleanup();
   });

--- a/my-app/src/components/MockupRedirect.jsx
+++ b/my-app/src/components/MockupRedirect.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import ProjectProgress from './ProjectProgress';
 
 const PROJECT_URL_MAP = {
@@ -50,7 +51,7 @@ const MockupRedirect = () => {
   const handleScrollToProgress = () => {
     const progressSection = document.getElementById('project-progress');
     if (progressSection) {
-      progressSection.scrollIntoView({ behavior: 'smooth' });
+      scrollIntoViewWithMotionPreference(progressSection);
     }
   };
 

--- a/my-app/src/components/Navegacion.js
+++ b/my-app/src/components/Navegacion.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import '../styles/components/Navegacion.css';
 
 function Navegacion() {
@@ -20,7 +21,7 @@ function Navegacion() {
   const handleScrollToElement = (id) => {
     const element = document.getElementById(id);
     if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
+      scrollIntoViewWithMotionPreference(element);
       closeMenu();
     }
   };

--- a/my-app/src/components/Portafolio.js
+++ b/my-app/src/components/Portafolio.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import '../styles/components/Portafolio.css';
 import '../styles/components/Timeline.css';
 import { getCurrentLanguage } from './utils/languageUtils';
@@ -349,7 +350,7 @@ const Portafolio = ({ style }) => {
   const handleScrollToSection = (id) => {
     const section = document.getElementById(id);
     if (section) {
-      section.scrollIntoView({ behavior: 'smooth' });
+      scrollIntoViewWithMotionPreference(section);
     }
   };
 

--- a/my-app/src/components/SEO.js
+++ b/my-app/src/components/SEO.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useLocation } from 'react-router-dom';
 
-const SITE_URL = 'https://www.elelier.com';
+const SITE_URL = 'https://elelier.com';
 const DEFAULT_OG_IMAGE = 'https://elelier.com/static/media/eleliercom.ced5bb90383175580555.png';
 
-function buildUrl(pathname = '/') {
-  const normalizedPath = pathname.startsWith('/') ? pathname : `/${pathname}`;
+export function buildUrl(pathname = '/') {
+  const sanitizedPath = `${pathname || '/'}`.split('?')[0].split('#')[0];
+  const normalizedPath = sanitizedPath.startsWith('/') ? sanitizedPath : `/${sanitizedPath}`;
   return `${SITE_URL}${normalizedPath}`;
 }
 
@@ -22,7 +23,7 @@ function SEO({
   locale = 'es_MX'
 }) {
   const location = useLocation();
-  const currentPath = pathname || `${location.pathname || '/'}${location.search || ''}`;
+  const currentPath = pathname || location.pathname || '/';
   const canonicalUrl = buildUrl(currentPath);
 
   return (

--- a/my-app/src/components/SEO.test.js
+++ b/my-app/src/components/SEO.test.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { buildUrl } from './SEO';
+
+describe('SEO', () => {
+  it('builds a canonical URL on elelier.com without query parameters', () => {
+    expect(buildUrl('/?utm_source=test&ref=1')).toBe('https://elelier.com/');
+    expect(buildUrl('/blog?utm_source=test')).toBe('https://elelier.com/blog');
+    expect(buildUrl('contacto?foo=bar')).toBe('https://elelier.com/contacto');
+  });
+});

--- a/my-app/src/components/Servicios.js
+++ b/my-app/src/components/Servicios.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import '../styles/components/Servicios.css';
 
 function Servicios({ style }) {
@@ -78,7 +79,7 @@ function Servicios({ style }) {
         ))}
       </div>
       <div className="servicio-cta global-cta">
-        <button className="cta-button-3" onClick={() => document.getElementById('contacto')?.scrollIntoView({ behavior: 'smooth' })}>{t.cta}</button>
+        <button className="cta-button-3" onClick={() => scrollIntoViewWithMotionPreference(document.getElementById('contacto'))}>{t.cta}</button>
         <div className="cta-helper-text">{t.ctaHelper}</div>
       </div>
       </div>

--- a/my-app/src/components/SettingsMenu.js
+++ b/my-app/src/components/SettingsMenu.js
@@ -9,6 +9,7 @@ const SettingsMenu = () => {
   const { language, toggleLanguage } = useLanguage();
   const menuRef = useRef(null);
   const menuPanelRef = useRef(null);
+  const toggleRef = useRef(null);
 
   const labels = {
     es: {
@@ -81,9 +82,32 @@ const SettingsMenu = () => {
     }
   }, [isMenuOpen]);
 
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+
+      event.preventDefault();
+      setIsMenuOpen(false);
+      toggleRef.current?.focus();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isMenuOpen]);
+
   return (
     <div className="settings-menu-container" ref={menuRef}>
       <button
+        ref={toggleRef}
         className="settings-toggle"
         type="button"
         aria-expanded={isMenuOpen}

--- a/my-app/src/components/SettingsMenu.js
+++ b/my-app/src/components/SettingsMenu.js
@@ -9,6 +9,27 @@ const SettingsMenu = () => {
   const { language, toggleLanguage } = useLanguage();
   const menuRef = useRef(null);
 
+  const labels = {
+    es: {
+      open: 'Abrir configuración',
+      close: 'Cerrar configuración',
+      light: 'Modo claro',
+      dark: 'Modo oscuro',
+      system: 'Tema del sistema',
+      language: 'Cambiar idioma a English'
+    },
+    en: {
+      open: 'Open settings',
+      close: 'Close settings',
+      light: 'Light mode',
+      dark: 'Dark mode',
+      system: 'System theme',
+      language: 'Switch language to Español'
+    }
+  };
+
+  const t = labels[language] || labels.en;
+
   useEffect(() => {
     const handleClickOutside = (event) => {
       if (menuRef.current && !menuRef.current.contains(event.target)) {
@@ -51,52 +72,73 @@ const SettingsMenu = () => {
     <div className="settings-menu-container" ref={menuRef}>
       <button
         className="settings-toggle"
-        aria-label="Toggle settings"
+        type="button"
+        aria-expanded={isMenuOpen}
+        aria-controls="settings-menu"
+        aria-label={isMenuOpen ? t.close : t.open}
         onClick={toggleMenu}
       >
-        <i className="fas fa-cog settings-icon" alt="Settings" />
+        <i className="fas fa-cog settings-icon" aria-hidden="true" />
       </button>
-      <div className={`settings-menu ${isMenuOpen ? 'open' : ''}`}>
-        <div
-          className={`settings-option ${currentTheme === 'light' ? 'active' : ''}`}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          onClick={() => handleThemeChange('light')}
-        >
-          <i className="fas fa-sun"></i>
-          <div className="tooltip">Light Mode</div>
+      <div id="settings-menu" className={`settings-menu ${isMenuOpen ? 'open' : ''}`}>
+        <div className="settings-theme-group">
+          <button
+            type="button"
+            data-settings-theme="light"
+            className="settings-option-button"
+            aria-pressed={currentTheme === 'light'}
+            aria-label={t.light}
+            onClick={() => handleThemeChange('light')}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            <i className="fas fa-sun" aria-hidden="true"></i>
+            <span className="tooltip">{t.light}</span>
+          </button>
+          <button
+            type="button"
+            data-settings-theme="dark"
+            className="settings-option-button"
+            aria-pressed={currentTheme === 'dark'}
+            aria-label={t.dark}
+            onClick={() => handleThemeChange('dark')}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            <i className="fas fa-moon" aria-hidden="true"></i>
+            <span className="tooltip">{t.dark}</span>
+          </button>
+          <button
+            type="button"
+            data-settings-theme="system"
+            className="settings-option-button"
+            aria-pressed={currentTheme === 'system'}
+            aria-label={t.system}
+            onClick={() => handleThemeChange('system')}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            <i className="fas fa-desktop" aria-hidden="true"></i>
+            <span className="tooltip">{t.system}</span>
+          </button>
         </div>
-        <div
-          className={`settings-option ${currentTheme === 'dark' ? 'active' : ''}`}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          onClick={() => handleThemeChange('dark')}
-        >
-          <i className="fas fa-moon"></i>
-          <div className="tooltip">Dark Mode</div>
-        </div>
-        <div
-          className={`settings-option ${currentTheme === 'system' ? 'active' : ''}`}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-          onClick={() => handleThemeChange('system')}
-        >
-          <i className="fas fa-desktop"></i>
-          <div className="tooltip">System Theme</div>
-        </div>
-        <div
+        <button
+          type="button"
+          data-settings-language
           className="settings-option language-toggle"
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
+          aria-label={t.language}
           onClick={toggleLanguage}
         >
           <img
             src={language === 'en' ? '/assets/files/flag-us.png' : '/assets/files/flag-mx.png'}
-            alt="Flag"
+            alt=""
+            aria-hidden="true"
             className="flag-image"
           />
-          <div className="tooltip">{language === 'en' ? 'English' : 'Español'}</div>
-        </div>
+          <span className="tooltip">{language === 'en' ? 'English' : 'Español'}</span>
+        </button>
       </div>
     </div>
   );

--- a/my-app/src/components/SettingsMenu.js
+++ b/my-app/src/components/SettingsMenu.js
@@ -8,6 +8,7 @@ const SettingsMenu = () => {
   const { currentTheme, setTheme } = useContext(ThemeContext);
   const { language, toggleLanguage } = useLanguage();
   const menuRef = useRef(null);
+  const menuPanelRef = useRef(null);
 
   const labels = {
     es: {
@@ -68,6 +69,18 @@ const SettingsMenu = () => {
     setTheme(theme);
   };
 
+  useEffect(() => {
+    if (!menuPanelRef.current) {
+      return;
+    }
+
+    if (isMenuOpen) {
+      menuPanelRef.current.removeAttribute('inert');
+    } else {
+      menuPanelRef.current.setAttribute('inert', '');
+    }
+  }, [isMenuOpen]);
+
   return (
     <div className="settings-menu-container" ref={menuRef}>
       <button
@@ -80,7 +93,12 @@ const SettingsMenu = () => {
       >
         <i className="fas fa-cog settings-icon" aria-hidden="true" />
       </button>
-      <div id="settings-menu" className={`settings-menu ${isMenuOpen ? 'open' : ''}`}>
+      <div
+        id="settings-menu"
+        ref={menuPanelRef}
+        className={`settings-menu ${isMenuOpen ? 'open' : ''}`}
+        aria-hidden={!isMenuOpen}
+      >
         <div className="settings-theme-group">
           <button
             type="button"

--- a/my-app/src/components/SettingsMenu.test.js
+++ b/my-app/src/components/SettingsMenu.test.js
@@ -81,6 +81,27 @@ describe('SettingsMenu', () => {
     cleanup();
   });
 
+  it('keeps the closed menu hidden from assistive tech and exposes it when open', () => {
+    const { container, cleanup } = renderSettingsMenu({ language: 'es', currentTheme: 'dark' });
+
+    const toggle = container.querySelector('.settings-toggle');
+    const panel = container.querySelector('#settings-menu');
+
+    expect(panel.getAttribute('aria-hidden')).toBe('true');
+    expect(panel.getAttribute('inert')).toBe('');
+    expect(panel.classList.contains('open')).toBe(false);
+
+    act(() => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(panel.getAttribute('aria-hidden')).toBe('false');
+    expect(panel.hasAttribute('inert')).toBe(false);
+    expect(panel.classList.contains('open')).toBe(true);
+
+    cleanup();
+  });
+
   it('switches language with an accessible destination label in English', () => {
     const { container, cleanup, toggleLanguage } = renderSettingsMenu({ language: 'en', currentTheme: 'light' });
 

--- a/my-app/src/components/SettingsMenu.test.js
+++ b/my-app/src/components/SettingsMenu.test.js
@@ -99,6 +99,21 @@ describe('SettingsMenu', () => {
     expect(panel.hasAttribute('inert')).toBe(false);
     expect(panel.classList.contains('open')).toBe(true);
 
+    const firstTheme = container.querySelector('[data-settings-theme="light"]');
+    firstTheme.focus();
+    expect(document.activeElement).toBe(firstTheme);
+
+    const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+    act(() => {
+      document.dispatchEvent(escapeEvent);
+    });
+
+    expect(escapeEvent.defaultPrevented).toBe(true);
+    expect(panel.getAttribute('aria-hidden')).toBe('true');
+    expect(panel.getAttribute('inert')).toBe('');
+    expect(panel.classList.contains('open')).toBe(false);
+    expect(document.activeElement).toBe(toggle);
+
     cleanup();
   });
 

--- a/my-app/src/components/SettingsMenu.test.js
+++ b/my-app/src/components/SettingsMenu.test.js
@@ -1,0 +1,98 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import SettingsMenu from './SettingsMenu';
+import { LanguageContext } from '../contexts/LanguageContext';
+import { ThemeContext } from '../contexts/ThemeContext';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderSettingsMenu = ({
+  language = 'es',
+  currentTheme = 'dark',
+  toggleLanguage = jest.fn(),
+  setTheme = jest.fn()
+} = {}) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <LanguageContext.Provider value={{ language, toggleLanguage }}>
+        <ThemeContext.Provider value={{ currentTheme, setTheme }}>
+          <SettingsMenu />
+        </ThemeContext.Provider>
+      </LanguageContext.Provider>
+    );
+  });
+
+  return {
+    container,
+    toggleLanguage,
+    setTheme,
+    cleanup: () => {
+      act(() => root.unmount());
+      container.remove();
+    }
+  };
+};
+
+describe('SettingsMenu', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('exposes the settings button with localized aria attributes and native controls', () => {
+    const { container, cleanup } = renderSettingsMenu({ language: 'es', currentTheme: 'dark' });
+
+    const toggle = container.querySelector('.settings-toggle');
+    expect(toggle.tagName).toBe('BUTTON');
+    expect(toggle.getAttribute('type')).toBe('button');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle.getAttribute('aria-controls')).toBe('settings-menu');
+    expect(toggle.getAttribute('aria-label')).toBe('Abrir configuración');
+
+    act(() => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+
+    const themeButtons = container.querySelectorAll('[data-settings-theme]');
+    expect(themeButtons).toHaveLength(3);
+    themeButtons.forEach((button) => {
+      expect(button.tagName).toBe('BUTTON');
+      expect(button.getAttribute('type')).toBe('button');
+    });
+
+    expect(container.querySelector('[data-settings-theme="light"]').getAttribute('aria-pressed')).toBe('false');
+    expect(container.querySelector('[data-settings-theme="dark"]').getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('[data-settings-theme="system"]').getAttribute('aria-pressed')).toBe('false');
+    expect(container.querySelector('[data-settings-theme="light"]').getAttribute('aria-label')).toBe('Modo claro');
+    expect(container.querySelector('[data-settings-theme="dark"]').getAttribute('aria-label')).toBe('Modo oscuro');
+    expect(container.querySelector('[data-settings-theme="system"]').getAttribute('aria-label')).toBe('Tema del sistema');
+
+    const languageButton = container.querySelector('[data-settings-language]');
+    expect(languageButton.tagName).toBe('BUTTON');
+    expect(languageButton.getAttribute('type')).toBe('button');
+    expect(languageButton.getAttribute('aria-label')).toBe('Cambiar idioma a English');
+    expect(languageButton.querySelector('img').getAttribute('aria-hidden')).toBe('true');
+
+    cleanup();
+  });
+
+  it('switches language with an accessible destination label in English', () => {
+    const { container, cleanup, toggleLanguage } = renderSettingsMenu({ language: 'en', currentTheme: 'light' });
+
+    const languageButton = container.querySelector('[data-settings-language]');
+    expect(languageButton.getAttribute('aria-label')).toBe('Switch language to Español');
+
+    act(() => {
+      languageButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(toggleLanguage).toHaveBeenCalled();
+
+    cleanup();
+  });
+});

--- a/my-app/src/components/SobreMi.js
+++ b/my-app/src/components/SobreMi.js
@@ -6,6 +6,7 @@ import professional from '../assets/images/ecommerce_marketing.png';
 import tech_vision from '../assets/images/technologic_vision.png';
 import { useSwipeable } from 'react-swipeable';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 
 function SobreMi({ style }) {
   const [currentSection, setCurrentSection] = useState(0);
@@ -173,11 +174,11 @@ function SobreMi({ style }) {
   });
 
   const scrollToServicios = () => {
-    document.getElementById('como-trabajo')?.scrollIntoView({ behavior: 'smooth' });
+    scrollIntoViewWithMotionPreference(document.getElementById('como-trabajo'));
   };
 
   const scrollToContacto = () => {
-    document.getElementById('contacto')?.scrollIntoView({ behavior: 'smooth' });
+    scrollIntoViewWithMotionPreference(document.getElementById('contacto'));
   };
 
   const handleManualChange = (index) => {

--- a/my-app/src/components/Soluciones.js
+++ b/my-app/src/components/Soluciones.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
+import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
 import '../styles/components/Soluciones.css';
 
 const content = {
@@ -76,7 +77,7 @@ function Soluciones({ style }) {
   const t = content[language] || content.es;
 
   const scrollToContacto = () => {
-    document.getElementById('contacto')?.scrollIntoView({ behavior: 'smooth' });
+    scrollIntoViewWithMotionPreference(document.getElementById('contacto'));
   };
 
   return (

--- a/my-app/src/components/utils/generalUtils.js
+++ b/my-app/src/components/utils/generalUtils.js
@@ -1,11 +1,57 @@
 // src/utils/generalUtils.js
 
+import { useEffect, useState } from 'react';
+
 // import { scrollToSection, loadExternalScripts, isMobile } from '../utils/generalUtils';
+
+export function prefersReducedMotion() {
+    return window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches || false;
+}
+
+export function usePrefersReducedMotion() {
+    const [reducedMotion, setReducedMotion] = useState(prefersReducedMotion());
+
+    useEffect(() => {
+        const mediaQuery = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+        if (!mediaQuery) {
+            return undefined;
+        }
+
+        const handleChange = (event) => {
+            setReducedMotion(event.matches);
+        };
+
+        setReducedMotion(mediaQuery.matches);
+
+        if (mediaQuery.addEventListener) {
+            mediaQuery.addEventListener('change', handleChange);
+            return () => mediaQuery.removeEventListener('change', handleChange);
+        }
+
+        mediaQuery.addListener(handleChange);
+        return () => mediaQuery.removeListener(handleChange);
+    }, []);
+
+    return reducedMotion;
+}
+
+export function getMotionAwareScrollBehavior() {
+    return prefersReducedMotion() ? 'auto' : 'smooth';
+}
+
+export function scrollIntoViewWithMotionPreference(element, options = {}) {
+    if (!element) {
+        return;
+    }
+
+    const behavior = options.behavior || getMotionAwareScrollBehavior();
+    element.scrollIntoView({ ...options, behavior });
+}
 
 export function scrollToSection(id) {
     const element = document.getElementById(id);
     if (element) {
-        element.scrollIntoView({ behavior: 'smooth' });
+        scrollIntoViewWithMotionPreference(element);
     }
 }
 

--- a/my-app/src/contexts/LanguageContext.js
+++ b/my-app/src/contexts/LanguageContext.js
@@ -10,10 +10,10 @@ export const LanguageProvider = ({ children }) => {
   useEffect(() => {
     updateDynamicContent(language);
     const htmlElement = document.getElementById('html-lang');
-  if (htmlElement) {
-    htmlElement.lang = language; // Actualiza el atributo lang
-  }
-}, [language]);
+    if (htmlElement) {
+      htmlElement.lang = language === 'es' ? 'es-MX' : 'en';
+    }
+  }, [language]);
 
   const toggleLanguage = () => {
     const newLanguage = language === 'es' ? 'en' : 'es';

--- a/my-app/src/contexts/LanguageContext.test.js
+++ b/my-app/src/contexts/LanguageContext.test.js
@@ -1,0 +1,60 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { LanguageProvider, useLanguage } from './LanguageContext';
+import { ThemeContext } from './ThemeContext';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const LangHarness = () => {
+  const { toggleLanguage } = useLanguage();
+
+  return (
+    <button type="button" onClick={toggleLanguage}>
+      Toggle language
+    </button>
+  );
+};
+
+describe('LanguageContext', () => {
+  beforeEach(() => {
+    document.documentElement.id = 'html-lang';
+    document.documentElement.lang = 'es-MX';
+    localStorage.clear();
+    localStorage.setItem('language', 'es');
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.documentElement.id = '';
+    document.documentElement.lang = 'en';
+    localStorage.clear();
+  });
+
+  it('updates html lang to es-MX and en as language changes', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <ThemeContext.Provider value={{ currentTheme: 'dark', setTheme: jest.fn() }}>
+          <LanguageProvider>
+            <LangHarness />
+          </LanguageProvider>
+        </ThemeContext.Provider>
+      );
+    });
+
+    expect(document.documentElement.lang).toBe('es-MX');
+
+    const toggle = container.querySelector('button');
+    act(() => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(document.documentElement.lang).toBe('en');
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/my-app/src/styles/components/ChatModal.css
+++ b/my-app/src/styles/components/ChatModal.css
@@ -164,6 +164,12 @@
   max-height: calc(100% - 140px) !important;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .chat-content {
+    scroll-behavior: auto !important;
+  }
+}
+
 .messages-container {
   flex: 1 !important;
   padding: clamp(0.5rem, 0.75rem, 1rem) clamp(0.75rem, 1rem, 1.25rem) !important;

--- a/my-app/src/styles/components/HeroBanner.css
+++ b/my-app/src/styles/components/HeroBanner.css
@@ -236,6 +236,8 @@ html { scroll-behavior: smooth; }
 @keyframes shine { to { background-position: 200% center; } }
 
 @media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+
   .hero-button,
   .hero-button-secondary,
   .scroll-arrow,
@@ -253,6 +255,10 @@ html { scroll-behavior: smooth; }
   .hero-button-secondary:hover,
   .hero-button-secondary:focus-visible {
     transform: none;
+  }
+
+  #star-canvas {
+    opacity: 0 !important;
   }
 }
 

--- a/my-app/src/styles/components/SettingsMenu.css
+++ b/my-app/src/styles/components/SettingsMenu.css
@@ -53,12 +53,14 @@
   transition: opacity 0.3s ease, transform 0.3s ease;
   opacity: 0;
   transform: translateY(-20px);
+  visibility: hidden;
   pointer-events: none;
 }
 
 .settings-menu.open {
   opacity: 1;
   transform: translateY(0);
+  visibility: visible;
   pointer-events: auto;
 }
 

--- a/my-app/src/styles/components/SettingsMenu.css
+++ b/my-app/src/styles/components/SettingsMenu.css
@@ -27,6 +27,7 @@
   font-size: 24px;
   cursor: pointer;
   transition: transform 0.3s ease;
+  padding: 0;
 }
 
 .settings-toggle:hover {
@@ -61,24 +62,38 @@
   pointer-events: auto;
 }
 
-.settings-option {
+.settings-theme-group {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.settings-option-button {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 40px;
   height: 40px;
-  cursor: pointer;
+  appearance: none;
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
   border-radius: 8px;
+  cursor: pointer;
   transition: background-color 0.3s, transform 0.3s;
 }
 
-.settings-option:hover {
+.settings-option-button:hover,
+.settings-option-button:focus-visible {
   background-color: var(--color-bg-2);
   color: var(--color-accent);
   transform: scale(1.1);
 }
 
-.settings-option.active {
+.settings-option-button[aria-pressed="true"] {
   background-color: var(--color-accent);
   color: var(--color-bg);
   transform: scale(0.95);
@@ -88,6 +103,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  background: none;
+  border: none;
+  padding: 0;
 }
 
 .flag-image {
@@ -109,9 +127,21 @@
   margin-top: 5px;
 }
 
-.settings-option:hover .tooltip {
+.settings-option-button:hover .tooltip,
+.settings-option-button:focus-visible .tooltip,
+.language-toggle:hover .tooltip,
+.language-toggle:focus-visible .tooltip {
   visibility: visible;
   opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-toggle,
+  .settings-option-button,
+  .language-toggle,
+  .settings-menu {
+    transition: none;
+  }
 }
 
 @media (max-width: 925px) {

--- a/my-app/src/styles/index.css
+++ b/my-app/src/styles/index.css
@@ -246,6 +246,21 @@ a {
   animation: none;
 }
 
+@media (prefers-reduced-motion: reduce) {
+  [data-chatbot-chat-widget-button],
+  [data-chatbot-chat-widget-button]:hover,
+  [data-chatbot-chat-widget-button]:active,
+  [data-chatbot-chat-widget-button] i,
+  [data-chatbot-chat-widget-button]::before {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  [data-chatbot-chat-widget-button] {
+    background-position: 0 0 !important;
+  }
+}
+
 /* Media queries para dispositivos móviles */
 @media (max-width: 600px) {
   #chatbot-chat-widget__container {


### PR DESCRIPTION
## Summary
- Promoted the hero message to the single H1 and kept the credential as non-heading supporting text.
- Added reduced-motion handling for the hero canvas, scroll behavior, and decorative motion surfaces.
- Converted SettingsMenu theme and language options into native accessible buttons.
- Normalized initial head metadata and runtime canonical URLs to elelier.com.

## Validation
- npm test -- --runInBand --watchAll=false
- npm run build
- git diff --check
