### PR TITLE
Iteración 13: coherencia de host en robots y sitemap

### DIFF
--- a/my-app/public/robots.txt
+++ b/my-app/public/robots.txt
@@ -3,4 +3,4 @@ Allow: /
 Disallow: /proyecto/
 Disallow: /admin/
 
-Sitemap: https://www.elelier.com/sitemap.xml
+Sitemap: https://elelier.com/sitemap.xml

--- a/my-app/public/sitemap.xml
+++ b/my-app/public/sitemap.xml
@@ -1,56 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.elelier.com/</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/</loc>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.elelier.com/portafolio</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/portafolio</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.elelier.com/sobre-mi</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/sobre-mi</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.elelier.com/servicios</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/servicios</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://www.elelier.com/contacto</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/contacto</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://www.elelier.com/blog</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/blog</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://www.elelier.com/aionlabs</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/aionlabs</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://www.elelier.com/privacy-policy</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/privacy-policy</loc>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
-    <loc>https://www.elelier.com/terms-of-service</loc>
-    <lastmod>2026-03-21</lastmod>
+    <loc>https://elelier.com/terms-of-service</loc>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>

--- a/my-app/src/staticSeoArtifacts.test.js
+++ b/my-app/src/staticSeoArtifacts.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const publicDir = path.resolve(__dirname, '../public');
+const robotsPath = path.join(publicDir, 'robots.txt');
+const sitemapPath = path.join(publicDir, 'sitemap.xml');
+
+function read(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function extractSitemapPaths(sitemap) {
+  return [...sitemap.matchAll(/<loc>https:\/\/[^/]+([^<]*)<\/loc>/g)].map(([, pathname]) =>
+    pathname || '/'
+  );
+}
+
+describe('static SEO artifacts', () => {
+  it('keeps the approved sitemap authority and legacy path set coherent', () => {
+    const robots = read(robotsPath);
+    const sitemap = read(sitemapPath);
+
+    expect(robots).toContain('Sitemap: https://elelier.com/sitemap.xml');
+    expect(robots).not.toContain('https://www.elelier.com/sitemap.xml');
+
+    expect(sitemap).not.toContain('https://www.elelier.com');
+    expect(sitemap).not.toContain('<lastmod>');
+    expect(extractSitemapPaths(sitemap)).toEqual([
+      '/',
+      '/portafolio',
+      '/sobre-mi',
+      '/servicios',
+      '/contacto',
+      '/blog',
+      '/aionlabs',
+      '/privacy-policy',
+      '/terms-of-service'
+    ]);
+  });
+});


### PR DESCRIPTION
## Resumen
- alinea `my-app/public/robots.txt` con `https://elelier.com/sitemap.xml`
- actualiza `my-app/public/sitemap.xml` para usar solo `https://elelier.com` y elimina `lastmod` fijos
- agrega una prueba enfocada para host, ausencia de `lastmod` y preservación exacta de paths

## Gate 0
- `main` ya contiene los merges de Iteración 11 (`c89b3fd`) y 12 (`a67002b`)
- la respuesta inicial pública de `https://elelier.com/` coincide con `main` en `title`, `html lang`, `meta description`, `og:url` y `JSON-LD url`
- `robots.txt` y `sitemap.xml` públicos siguen usando `www.elelier.com`, coherente con `main` pero no con la autoridad aprobada

## Validación
- `npm test -- --runInBand --watchAll=false`
- `npm run build`
- `git diff --check`
- `git restore src/config/hashedPasscodes.js`
- `git status --short`