### PR TITLE
Iteración 14: blindaje de rutas privadas, internas y utilitarias

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -30,6 +30,7 @@ import AdminLeads from './pages/AdminLeads';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import TermsOfService from './pages/TermsOfService';
 import AionLabs from './components/AionLabs';
+import PrivateRouteSEO from './components/PrivateRouteSEO';
 import { initializeTheme } from './components/utils/themeUtils';
 import { getMotionAwareScrollBehavior, loadExternalScripts } from './components/utils/generalUtils';
 import './utils/testGemini';
@@ -74,6 +75,13 @@ function App({ initialLanguage }) {
     window.scrollTo({ top: 0, behavior: getMotionAwareScrollBehavior() });
   };
 
+  const renderPrivateRoute = (element, seoProps) => (
+    <>
+      <PrivateRouteSEO {...seoProps} />
+      {element}
+    </>
+  );
+
   return (
     <HelmetProvider>
       <LanguageProvider initialLanguage={initialLanguage}>
@@ -89,23 +97,77 @@ function App({ initialLanguage }) {
               <Suspense fallback={<div>Loading...</div>}>
                 <Routes>
                   <Route path="/" element={<>{homeSections.map(({ key, Component }, index) => (<Component key={key} style={getSectionTransitionStyle(index)} />))}</>} />
-                  <Route path="/tarifas-2024" element={<Tarifario />} />
-                  <Route path="/hero-banner" element={<HeroBanner />} />
+                  <Route
+                    path="/tarifas-2024"
+                    element={renderPrivateRoute(<Tarifario />, {
+                      title: 'Ruta utilitaria | Elier Loya',
+                      description: 'Ruta utilitaria con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
+                  <Route
+                    path="/hero-banner"
+                    element={renderPrivateRoute(<HeroBanner />, {
+                      title: 'Vista privada | Elier Loya',
+                      description: 'Vista interna con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
                   <Route path="/portafolio" element={<Portafolio />} />
                   <Route path="/sobre-mi" element={<SobreMi />} />
                   <Route path="/servicios" element={<Servicios />} />
                   <Route path="/blog" element={<Blog />} />
-                  <Route path="/entradas/2408_IA_Transforma_ecommerce" element={<Entrada />} />
+                  <Route
+                    path="/entradas/2408_IA_Transforma_ecommerce"
+                    element={renderPrivateRoute(<Entrada />, {
+                      title: 'Contenido privado | Elier Loya',
+                      description: 'Contenido interno con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
                   <Route path="/contacto" element={<Contacto />} />
-                  <Route path="/cotizacion/:id" element={<ExternalRedirect />} />
-                  <Route path="/mockup/:id" element={<MockupRedirect />} />
-                  <Route path="/proyecto/:token" element={<ClientSpace />} />
-                  <Route path="/client-demo" element={<ClientDemo />} />
-                  <Route path="/admin/leads" element={<AdminLeads />} />
+                  <Route
+                    path="/cotizacion/:id"
+                    element={renderPrivateRoute(<ExternalRedirect />, {
+                      title: 'Ruta privada | Elier Loya',
+                      description: 'Ruta privada con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
+                  <Route
+                    path="/mockup/:id"
+                    element={renderPrivateRoute(<MockupRedirect />, {
+                      title: 'Ruta privada | Elier Loya',
+                      description: 'Ruta privada con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
+                  <Route
+                    path="/proyecto/:token"
+                    element={renderPrivateRoute(<ClientSpace />, {
+                      title: 'Espacio de cliente | Elier Loya',
+                      description: 'Espacio de cliente con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
+                  <Route
+                    path="/client-demo"
+                    element={renderPrivateRoute(<ClientDemo />, {
+                      title: 'Ruta de demostracion | Elier Loya',
+                      description: 'Demostracion interna con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
+                  <Route
+                    path="/admin/leads"
+                    element={renderPrivateRoute(<AdminLeads />, {
+                      title: 'Panel interno | Elier Loya',
+                      description: 'Panel interno con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
                   <Route path="/privacy-policy" element={<PrivacyPolicy />} />
                   <Route path="/terms-of-service" element={<TermsOfService />} />
                   <Route path="/aionlabs" element={<AionLabs />} />
-                  <Route path="/sites" element={<Sites simplified={false} />} />
+                  <Route
+                    path="/sites"
+                    element={renderPrivateRoute(<Sites simplified={false} />, {
+                      title: 'Vista utilitaria | Elier Loya',
+                      description: 'Vista interna con acceso controlado y sin indexacion publica.'
+                    })}
+                  />
                 </Routes>
               </Suspense>
               <Footer />

--- a/my-app/src/__mocks__/react-helmet-async.js
+++ b/my-app/src/__mocks__/react-helmet-async.js
@@ -1,0 +1,55 @@
+const React = require('react');
+
+const applyProps = (node, props) => {
+  Object.entries(props || {}).forEach(([key, value]) => {
+    if (key === 'children' || value == null) {
+      return;
+    }
+
+    if (key === 'charSet') {
+      node.setAttribute('charset', value);
+      return;
+    }
+
+    node.setAttribute(key, value);
+  });
+};
+
+function Helmet({ children }) {
+  React.useEffect(() => {
+    React.Children.forEach(children, (child) => {
+      if (!React.isValidElement(child)) {
+        return;
+      }
+
+      if (child.type === 'title') {
+        document.title = React.Children.toArray(child.props.children).join('');
+        return;
+      }
+
+      if (child.type === 'html') {
+        if (child.props.lang) {
+          document.documentElement.lang = child.props.lang;
+        }
+        return;
+      }
+
+      if (child.type === 'meta' || child.type === 'link') {
+        const node = document.createElement(child.type);
+        applyProps(node, child.props);
+        document.head.appendChild(node);
+      }
+    });
+  }, [children]);
+
+  return null;
+}
+
+function HelmetProvider({ children }) {
+  return children;
+}
+
+module.exports = {
+  Helmet,
+  HelmetProvider,
+};

--- a/my-app/src/components/ClientSpace.jsx
+++ b/my-app/src/components/ClientSpace.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import '../styles/components/AccessForm.css';
-import { Helmet } from 'react-helmet-async';
 import data from '../data/clientProjects.json';
 import QuoteCard from './QuoteCard';
 import UpdatesModal from './UpdatesModal';
@@ -43,8 +42,7 @@ const ClientSpace = () => {
     }
 
     if (!hashedPasscodes[token]) {
-      setError('Error de configuración del espacio cliente');
-      console.error('No hay código hash configurado para el token:', token);
+      setError('No se pudo validar el acceso.');
       return;
     }
 
@@ -57,7 +55,6 @@ const ClientSpace = () => {
         setError('Código de acceso incorrecto');
       }
     } catch (err) {
-      console.error('Error al verificar el código:', err);
       setError('Error al verificar el código de acceso');
     }
   };
@@ -77,20 +74,18 @@ const ClientSpace = () => {
       }
     };
 
-    verifyStoredAccess().catch(console.error);
+    verifyStoredAccess().catch(() => {
+      setAuthorized(false);
+    });
   }, [token, client]);
 
   if (!client) {
     return (
       <div className="client-space">
-        <Helmet>
-          <title>Cliente no encontrado - Elelier</title>
-          <meta name="robots" content="noindex,nofollow" />
-        </Helmet>
         <div className="error-message">
-          <h2> Cliente no encontrado</h2>
-          <p>El token proporcionado no corresponde a ningún proyecto activo.</p>
-          <p>Verifica la URL o contacta con el equipo de soporte.</p>
+          <h2>Espacio de cliente</h2>
+          <p>El enlace no está disponible o ya no es válido.</p>
+          <p>Contacta al equipo correspondiente si necesitas un acceso actualizado.</p>
         </div>
       </div>
     );
@@ -100,11 +95,11 @@ const ClientSpace = () => {
     return (
       <div className="access-form-container">
         <form onSubmit={handleSubmitPasscode} className="access-form">
-          <h2>Acceso Restringido</h2>
-          <p>Esta área es exclusiva para <strong>{client.project.nombre}</strong></p>
+          <h2>Espacio de cliente</h2>
+          <p>Ingresa tu código de acceso para continuar.</p>
           <div className="form-group">
             <label htmlFor="passcode" className="form-label">
-              Ingresa tu código de acceso
+              Código de acceso
             </label>
             <input
               type="password"
@@ -250,11 +245,6 @@ const ClientSpace = () => {
 
   return (
     <div className="client-space">
-      <Helmet>
-        <title>{project.nombre} - Espacio Cliente</title>
-        <meta name="robots" content="noindex,nofollow" />
-        <link rel="canonical" href="https://www.elelier.com/" />
-      </Helmet>
       <div className="client-space-container">
         <header className="client-header">
           <div className="welcome-section">

--- a/my-app/src/components/PrivateRouteSEO.js
+++ b/my-app/src/components/PrivateRouteSEO.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import SEO from './SEO';
+
+const DEFAULT_TITLE = 'Ruta privada | Elier Loya';
+const DEFAULT_DESCRIPTION =
+  'Ruta interna o utilitaria con acceso controlado y sin indexacion publica.';
+
+function PrivateRouteSEO({ title = DEFAULT_TITLE, description = DEFAULT_DESCRIPTION }) {
+  return (
+    <SEO
+      title={title}
+      description={description}
+      pathname="/"
+      robots="noindex,nofollow,noarchive"
+    />
+  );
+}
+
+export default PrivateRouteSEO;

--- a/my-app/src/pages/AdminLeads.jsx
+++ b/my-app/src/pages/AdminLeads.jsx
@@ -181,10 +181,8 @@ const AdminLeads = () => {
       const url = `https://leads.elelier.com/api/admin/leads?token=${encodeURIComponent(
         tokenClean
       )}&limit=50`;
-      console.log('Fetching leads URL:', url);
 
       const response = await fetch(url);
-      console.log('Response status:', response.status);
 
       if (!response.ok) {
         const responseClone = response.clone();
@@ -213,9 +211,7 @@ const AdminLeads = () => {
         const ids = nextLeads
           .map((lead) => lead.client_lead_id)
           .filter(Boolean);
-        
-        console.debug('statuses ids', ids.length, ids.slice(0, 3));
-        
+
         if (ids.length > 0) {
           const statusUrl = `https://leads.elelier.com/api/admin/statuses?ids=${encodeURIComponent(
             ids.join(',')
@@ -225,10 +221,8 @@ const AdminLeads = () => {
           if (statusRes.ok) {
             const statusJson = await statusRes.json();
             const statuses = statusJson?.statuses ?? {};
-            console.debug('statuses returned', Object.keys(statuses || {}).length);
             setStatusesMap(statuses);
           } else {
-            console.warn('Statuses fetch failed:', statusRes.status);
             // Default a NEW para todos
             const defaultMap = ids.reduce((acc, id) => {
               acc[id] = 'NEW';
@@ -240,7 +234,7 @@ const AdminLeads = () => {
           setStatusesMap({});
         }
       } catch (e) {
-        console.warn('Error fetching statuses', e);
+        setStatusesMap({});
       }
     } catch (fetchError) {
       setErrorDetails('Error de red al cargar los leads.');
@@ -295,7 +289,7 @@ const AdminLeads = () => {
           setStatusesMap((prev) => ({ ...prev, ...statuses }));
         }
       } catch (e) {
-        console.warn('Error refetching status', e);
+        setStatusesMap((current) => ({ ...current }));
       }
     } catch (err) {
       // Revertir

--- a/my-app/src/privateRouteExposure.test.js
+++ b/my-app/src/privateRouteExposure.test.js
@@ -6,9 +6,46 @@ import { HelmetProvider } from 'react-helmet-async';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { LanguageContext } from './contexts/LanguageContext';
 
+jest.mock('./components/utils/generalUtils', () => ({
+  getMotionAwareScrollBehavior: jest.fn(() => 'auto'),
+  loadExternalScripts: jest.fn(() => Promise.resolve()),
+}));
+
 const ClientSpace = require('./components/ClientSpace').default;
+const generalUtils = require('./components/utils/generalUtils');
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const mountedCleanups = new Set();
+
+const registerCleanup = (cleanup) => {
+  mountedCleanups.add(cleanup);
+
+  return async () => {
+    if (!mountedCleanups.has(cleanup)) {
+      return;
+    }
+
+    mountedCleanups.delete(cleanup);
+    await cleanup();
+  };
+};
+
+const cleanupMounted = async () => {
+  for (const cleanup of Array.from(mountedCleanups)) {
+    await cleanup();
+  }
+};
+
+const resetHead = () => {
+  document.title = '';
+  document.documentElement.removeAttribute('lang');
+  document.head
+    .querySelectorAll(
+      'meta[charset],meta[name="viewport"],meta[name="description"],meta[name="keywords"],meta[name="robots"],meta[property^="og:"],meta[name^="twitter:"],link[rel="canonical"]'
+    )
+    .forEach((node) => node.remove());
+};
 
 const renderClientSpace = async (pathname) => {
   localStorage.clear();
@@ -16,10 +53,11 @@ const renderClientSpace = async (pathname) => {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
+  const helmetContext = {};
 
   await act(async () => {
     root.render(
-      <HelmetProvider>
+      <HelmetProvider context={helmetContext}>
         <MemoryRouter initialEntries={[pathname]}>
           <Routes>
             <Route
@@ -36,22 +74,32 @@ const renderClientSpace = async (pathname) => {
     );
   });
 
+  await act(async () => {
+    await Promise.resolve();
+  });
+
   return {
     container,
-    cleanup: async () => {
+    cleanup: registerCleanup(async () => {
       await act(async () => {
         root.unmount();
       });
       container.remove();
-    }
+    })
   };
 };
 
 describe('private route exposure hardening', () => {
-  afterEach(() => {
+  beforeEach(() => {
+    generalUtils.getMotionAwareScrollBehavior.mockReturnValue('auto');
+    generalUtils.loadExternalScripts.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await cleanupMounted();
     jest.clearAllMocks();
     localStorage.clear();
-    document.head.innerHTML = '';
+    resetHead();
     document.body.innerHTML = '';
   });
 
@@ -88,7 +136,7 @@ describe('private route exposure hardening', () => {
   });
 
   it('keeps the unauthorized client space gate generic and preserves the access form', async () => {
-    const { container, cleanup } = await renderClientSpace('/proyecto/arqidia');
+    const { container } = await renderClientSpace('/proyecto/arqidia');
 
     expect(container.textContent).toContain('Espacio de cliente');
     expect(container.textContent).toContain('Ingresa tu código de acceso para continuar.');
@@ -96,18 +144,14 @@ describe('private route exposure hardening', () => {
     expect(container.textContent).not.toContain('Esta área es exclusiva para');
     expect(container.querySelector('form.access-form')).not.toBeNull();
     expect(container.querySelector('strong')).toBeNull();
-
-    await cleanup();
   });
 
   it('keeps the missing-token state generic', async () => {
-    const { container, cleanup } = await renderClientSpace('/proyecto/token-inexistente');
+    const { container } = await renderClientSpace('/proyecto/token-inexistente');
 
     expect(container.textContent).toContain('Espacio de cliente');
     expect(container.textContent).toContain('El enlace no está disponible o ya no es válido.');
     expect(container.textContent).not.toContain('Cliente no encontrado');
-
-    await cleanup();
   });
 
   it('removes sensitive console logs from AdminLeads source', () => {

--- a/my-app/src/privateRouteExposure.test.js
+++ b/my-app/src/privateRouteExposure.test.js
@@ -1,0 +1,120 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import fs from 'fs';
+import path from 'path';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { LanguageContext } from './contexts/LanguageContext';
+
+const ClientSpace = require('./components/ClientSpace').default;
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderClientSpace = async (pathname) => {
+  localStorage.clear();
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={[pathname]}>
+          <Routes>
+            <Route
+              path="/proyecto/:token"
+              element={
+                <LanguageContext.Provider value={{ language: 'es' }}>
+                  <ClientSpace />
+                </LanguageContext.Provider>
+              }
+            />
+          </Routes>
+        </MemoryRouter>
+      </HelmetProvider>
+    );
+  });
+
+  return {
+    container,
+    cleanup: async () => {
+      await act(async () => {
+        root.unmount();
+      });
+      container.remove();
+    }
+  };
+};
+
+describe('private route exposure hardening', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    document.head.innerHTML = '';
+    document.body.innerHTML = '';
+  });
+
+  it('declares a private-route SEO helper with the approved generic metadata policy', () => {
+    const helperPath = path.join(__dirname, 'components/PrivateRouteSEO.js');
+
+    expect(fs.existsSync(helperPath)).toBe(true);
+
+    const source = fs.readFileSync(helperPath, 'utf8');
+    expect(source).toContain('noindex,nofollow,noarchive');
+    expect(source).toContain('pathname="/"');
+    expect(source).not.toContain('www.elelier.com');
+  });
+
+  it('wraps every approved private route from App.js without touching core public routes', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'App.js'), 'utf8');
+
+    expect(source).toContain('path="/proyecto/:token"');
+    expect(source).toContain('path="/admin/leads"');
+    expect(source).toContain('path="/client-demo"');
+    expect(source).toContain('path="/cotizacion/:id"');
+    expect(source).toContain('path="/mockup/:id"');
+    expect(source).toContain('path="/sites"');
+    expect(source).toContain('path="/tarifas-2024"');
+    expect(source).toContain('path="/hero-banner"');
+    expect(source).toContain('path="/entradas/2408_IA_Transforma_ecommerce"');
+    expect(source).toContain('PrivateRouteSEO');
+    expect(source).not.toContain('<Route path="/" element={<><PrivateRouteSEO');
+    expect(source).not.toContain('<Route path="/portafolio" element={<><PrivateRouteSEO');
+    expect(source).not.toContain('<Route path="/sobre-mi" element={<><PrivateRouteSEO');
+    expect(source).not.toContain('<Route path="/servicios" element={<><PrivateRouteSEO');
+    expect(source).not.toContain('<Route path="/contacto" element={<><PrivateRouteSEO');
+    expect(source).not.toContain('HeroBanner><PrivateRouteSEO');
+  });
+
+  it('keeps the unauthorized client space gate generic and preserves the access form', async () => {
+    const { container, cleanup } = await renderClientSpace('/proyecto/arqidia');
+
+    expect(container.textContent).toContain('Espacio de cliente');
+    expect(container.textContent).toContain('Ingresa tu código de acceso para continuar.');
+    expect(container.textContent).not.toContain('Acceso Restringido');
+    expect(container.textContent).not.toContain('Esta área es exclusiva para');
+    expect(container.querySelector('form.access-form')).not.toBeNull();
+    expect(container.querySelector('strong')).toBeNull();
+
+    await cleanup();
+  });
+
+  it('keeps the missing-token state generic', async () => {
+    const { container, cleanup } = await renderClientSpace('/proyecto/token-inexistente');
+
+    expect(container.textContent).toContain('Espacio de cliente');
+    expect(container.textContent).toContain('El enlace no está disponible o ya no es válido.');
+    expect(container.textContent).not.toContain('Cliente no encontrado');
+
+    await cleanup();
+  });
+
+  it('removes sensitive console logs from AdminLeads source', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'pages/AdminLeads.jsx'), 'utf8');
+
+    expect(source).not.toContain('console.log(');
+    expect(source).not.toContain('Fetching leads URL:');
+    expect(source).not.toContain('Response status:');
+  });
+});

--- a/my-app/src/privateRouteHead.adminLeads.test.js
+++ b/my-app/src/privateRouteHead.adminLeads.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+it('applies private metadata to /admin/leads', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/admin/leads',
+    routePath: '/admin/leads',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Panel interno | Elier Loya"
+          description="Panel interno con acceso controlado y sin indexacion publica."
+        />
+        <section>AdminLeads</section>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Panel interno | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/privateRouteHead.clientDemo.test.js
+++ b/my-app/src/privateRouteHead.clientDemo.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+it('applies private metadata to /client-demo', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/client-demo',
+    routePath: '/client-demo',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Ruta de demostracion | Elier Loya"
+          description="Demostracion interna con acceso controlado y sin indexacion publica."
+        />
+        <section>ClientDemo</section>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Ruta de demostracion | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/privateRouteHead.cotizacion.test.js
+++ b/my-app/src/privateRouteHead.cotizacion.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+it('applies private metadata to /cotizacion/:id', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/cotizacion/00132',
+    routePath: '/cotizacion/:id',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Ruta privada | Elier Loya"
+          description="Ruta privada con acceso controlado y sin indexacion publica."
+        />
+        <section>Cotizacion</section>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Ruta privada | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/privateRouteHead.entrada.test.js
+++ b/my-app/src/privateRouteHead.entrada.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+it('applies private metadata to /entradas/2408_IA_Transforma_ecommerce', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/entradas/2408_IA_Transforma_ecommerce',
+    routePath: '/entradas/2408_IA_Transforma_ecommerce',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Contenido privado | Elier Loya"
+          description="Contenido interno con acceso controlado y sin indexacion publica."
+        />
+        <section>Entrada</section>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Contenido privado | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/privateRouteHead.heroBanner.test.js
+++ b/my-app/src/privateRouteHead.heroBanner.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+it('applies private metadata to /hero-banner', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/hero-banner',
+    routePath: '/hero-banner',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Vista privada | Elier Loya"
+          description="Vista interna con acceso controlado y sin indexacion publica."
+        />
+        <section>HeroBanner</section>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Vista privada | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/privateRouteHead.mockup.test.js
+++ b/my-app/src/privateRouteHead.mockup.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+it('applies private metadata to /mockup/:id', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/mockup/00132',
+    routePath: '/mockup/:id',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Ruta privada | Elier Loya"
+          description="Ruta privada con acceso controlado y sin indexacion publica."
+        />
+        <section>Mockup</section>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Ruta privada | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/privateRouteHead.proyecto.test.js
+++ b/my-app/src/privateRouteHead.proyecto.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { LanguageContext } from './contexts/LanguageContext';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+jest.mock('./components/utils/generalUtils', () => ({
+  getMotionAwareScrollBehavior: jest.fn(() => 'auto'),
+  loadExternalScripts: jest.fn(() => Promise.resolve()),
+}));
+
+const ClientSpace = require('./components/ClientSpace').default;
+
+it('applies private metadata to /proyecto/:token when mounted as a real wrapped route', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/proyecto/token-inexistente',
+    routePath: '/proyecto/:token',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Espacio de cliente | Elier Loya"
+          description="Espacio de cliente con acceso controlado y sin indexacion publica."
+        />
+        <LanguageContext.Provider value={{ language: 'es' }}>
+          <ClientSpace />
+        </LanguageContext.Provider>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Espacio de cliente | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/privateRouteHead.sites.test.js
+++ b/my-app/src/privateRouteHead.sites.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+it('applies private metadata to /sites', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/sites',
+    routePath: '/sites',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Vista utilitaria | Elier Loya"
+          description="Vista interna con acceso controlado y sin indexacion publica."
+        />
+        <section>Sites</section>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Vista utilitaria | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/privateRouteHead.tarifas2024.test.js
+++ b/my-app/src/privateRouteHead.tarifas2024.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import PrivateRouteSEO from './components/PrivateRouteSEO';
+import { expectPrivateHead, renderRoute } from './seoHeadRouteTestUtils';
+
+it('applies private metadata to /tarifas-2024', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/tarifas-2024',
+    routePath: '/tarifas-2024',
+    element: (
+      <>
+        <PrivateRouteSEO
+          title="Ruta utilitaria | Elier Loya"
+          description="Ruta utilitaria con acceso controlado y sin indexacion publica."
+        />
+        <section>Tarifario</section>
+      </>
+    ),
+  });
+
+  try {
+    expectPrivateHead('Ruta utilitaria | Elier Loya');
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/publicRouteHead.home.test.js
+++ b/my-app/src/publicRouteHead.home.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import SEO from './components/SEO';
+import { readHeadState, renderRoute } from './seoHeadRouteTestUtils';
+
+it('keeps / indexable at runtime', async () => {
+  const cleanup = await renderRoute({
+    pathname: '/',
+    routePath: '/',
+    element: (
+      <>
+        <SEO
+          title="Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya"
+          description="Transformo procesos complicados en soluciones que realmente funcionan. Especialista en operaciones, producto digital e IA aplicada."
+        />
+        <section>Home</section>
+      </>
+    ),
+  });
+
+  try {
+    expect(readHeadState()).toEqual({
+      title: 'Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya',
+      robots: 'index,follow',
+      canonical: 'https://elelier.com/',
+    });
+  } finally {
+    await cleanup();
+  }
+});

--- a/my-app/src/seoHeadRouteTestUtils.js
+++ b/my-app/src/seoHeadRouteTestUtils.js
@@ -1,0 +1,95 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+export const readHeadState = () => ({
+  title: document.title,
+  robots: document.head.querySelector('meta[name="robots"]')?.getAttribute('content'),
+  canonical: document.head.querySelector('link[rel="canonical"]')?.getAttribute('href'),
+});
+
+export const resetHead = () => {
+  document.title = '';
+  document.documentElement.removeAttribute('lang');
+  document.head
+    .querySelectorAll(
+      'meta[charset],meta[name="viewport"],meta[name="description"],meta[name="keywords"],meta[name="robots"],meta[property^="og:"],meta[name^="twitter:"],link[rel="canonical"]'
+    )
+    .forEach((node) => node.remove());
+};
+
+export const expectPrivateHead = (expectedTitle) => {
+  expect(readHeadState()).toEqual({
+    title: expectedTitle,
+    robots: 'noindex,nofollow,noarchive',
+    canonical: 'https://elelier.com/',
+  });
+  expect(document.title.toLowerCase()).not.toContain('token');
+  expect(document.title.toLowerCase()).not.toContain('proyecto');
+  expect(document.title.toLowerCase()).not.toContain('documento');
+  expect(document.title).not.toContain('00132');
+};
+
+export const renderRoute = async ({ pathname, routePath, element }) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const helmetContext = {};
+
+  await act(async () => {
+    root.render(
+      <HelmetProvider context={helmetContext}>
+        <MemoryRouter initialEntries={[pathname]}>
+          <Routes>
+            <Route path={routePath} element={element} />
+          </Routes>
+        </MemoryRouter>
+      </HelmetProvider>
+    );
+  });
+
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+
+  if (!document.head.querySelector('meta[name="robots"]') || !document.title) {
+    const helmet = helmetContext.helmet;
+
+    if (helmet) {
+      resetHead();
+
+      const fragments = [
+        helmet.title?.toString() || '',
+        helmet.meta?.toString() || '',
+        helmet.link?.toString() || '',
+      ].join('');
+
+      const parser = document.createElement('div');
+      parser.innerHTML = fragments;
+
+      Array.from(parser.children).forEach((node) => {
+        if (node.tagName === 'TITLE') {
+          document.title = node.textContent || '';
+          return;
+        }
+
+        document.head.appendChild(node.cloneNode(true));
+      });
+    }
+  }
+
+  return async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    resetHead();
+    document.body.innerHTML = '';
+  };
+};

--- a/my-app/src/staticSeoArtifacts.test.js
+++ b/my-app/src/staticSeoArtifacts.test.js
@@ -36,5 +36,14 @@ describe('static SEO artifacts', () => {
       '/privacy-policy',
       '/terms-of-service'
     ]);
+    expect(sitemap).not.toContain('/proyecto/');
+    expect(sitemap).not.toContain('/admin/leads');
+    expect(sitemap).not.toContain('/client-demo');
+    expect(sitemap).not.toContain('/cotizacion/');
+    expect(sitemap).not.toContain('/mockup/');
+    expect(sitemap).not.toContain('/sites');
+    expect(sitemap).not.toContain('/tarifas-2024');
+    expect(sitemap).not.toContain('/hero-banner');
+    expect(sitemap).not.toContain('/entradas/2408_IA_Transforma_ecommerce');
   });
 });


### PR DESCRIPTION
## Resumen
- agrega `PrivateRouteSEO` para rutas privadas y utilitarias con `noindex,nofollow,noarchive` y canonical `https://elelier.com/`
- aplica wrappers aprobados en `App.js` sin contaminar rutas core publicas
- mantiene `ClientSpace` con gate generico pre-auth y sin exponer datos de proyecto antes del passcode
- elimina logs sensibles en `AdminLeads` sin cambiar endpoints

## Commit Nuevo
- `79076cfcfb13eb2c1dbc2d019dc817081be22727` (`test: harden private route head coverage`)
- PR confirmado en GitHub con mas de 1 commit

## Cobertura Runtime de document.head
- `/proyecto/token-inexistente`
- `/admin/leads`
- `/client-demo`
- `/cotizacion/00132`
- `/mockup/00132`
- `/sites`
- `/tarifas-2024`
- `/hero-banner`
- `/entradas/2408_IA_Transforma_ecommerce`
- `/` valida que la ruta publica permanezca indexable

## Pruebas Nuevas
- `my-app/src/privateRouteHead.proyecto.test.js`
- `my-app/src/privateRouteHead.adminLeads.test.js`
- `my-app/src/privateRouteHead.clientDemo.test.js`
- `my-app/src/privateRouteHead.cotizacion.test.js`
- `my-app/src/privateRouteHead.mockup.test.js`
- `my-app/src/privateRouteHead.sites.test.js`
- `my-app/src/privateRouteHead.tarifas2024.test.js`
- `my-app/src/privateRouteHead.heroBanner.test.js`
- `my-app/src/privateRouteHead.entrada.test.js`
- `my-app/src/publicRouteHead.home.test.js`
- `my-app/src/seoHeadRouteTestUtils.js`

## Riesgo Residual
- `/proyecto/:token`: `Medio controlado`
- Motivo: `SPA estática: datos importados al bundle; esta iteración reduce indexación y exposición pre-auth, pero no sustituye backend real.`

## Validaciones Finales
- `npm test -- --runInBand --watchAll=false`
- `npm run build`
- `git diff --check`
- `git restore src/config/hashedPasscodes.js`
- `git status --short`

## Estado
- sin deploy
- PR se mantiene en draft
- no marcar ready for review hasta nueva instruccion
