### PR TITLE
Iteración 14.1: cerrar exposición visual de rutas privadas/utilitarias

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -21,16 +21,14 @@ import Tarifario from './components/Tarifario';
 import FloatingButton from './components/FloatingButton';
 import ChatModal from './components/ChatModal';
 import ExternalRedirect from './components/ExternalRedirect';
-import MockupRedirect from './components/MockupRedirect';
 import ClientSpace from './components/ClientSpace';
-import ClientDemo from './components/ClientDemo';
-import Sites from './components/Sites';
 import SettingsMenu from './components/SettingsMenu';
 import AdminLeads from './pages/AdminLeads';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import TermsOfService from './pages/TermsOfService';
 import AionLabs from './components/AionLabs';
 import PrivateRouteSEO from './components/PrivateRouteSEO';
+import InternalRoutePlaceholder from './components/InternalRoutePlaceholder';
 import { initializeTheme } from './components/utils/themeUtils';
 import { getMotionAwareScrollBehavior, loadExternalScripts } from './components/utils/generalUtils';
 import './utils/testGemini';
@@ -40,7 +38,6 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 const Blog = lazy(() => import('./components/Blog'));
-const Entrada = lazy(() => import('./components/entradas/entrada1'));
 
 function App({ initialLanguage }) {
   const homeSectionPalette = [
@@ -117,7 +114,7 @@ function App({ initialLanguage }) {
                   <Route path="/blog" element={<Blog />} />
                   <Route
                     path="/entradas/2408_IA_Transforma_ecommerce"
-                    element={renderPrivateRoute(<Entrada />, {
+                    element={renderPrivateRoute(<InternalRoutePlaceholder />, {
                       title: 'Contenido privado | Elier Loya',
                       description: 'Contenido interno con acceso controlado y sin indexacion publica.'
                     })}
@@ -132,7 +129,7 @@ function App({ initialLanguage }) {
                   />
                   <Route
                     path="/mockup/:id"
-                    element={renderPrivateRoute(<MockupRedirect />, {
+                    element={renderPrivateRoute(<InternalRoutePlaceholder />, {
                       title: 'Ruta privada | Elier Loya',
                       description: 'Ruta privada con acceso controlado y sin indexacion publica.'
                     })}
@@ -146,7 +143,7 @@ function App({ initialLanguage }) {
                   />
                   <Route
                     path="/client-demo"
-                    element={renderPrivateRoute(<ClientDemo />, {
+                    element={renderPrivateRoute(<InternalRoutePlaceholder />, {
                       title: 'Ruta de demostracion | Elier Loya',
                       description: 'Demostracion interna con acceso controlado y sin indexacion publica.'
                     })}
@@ -163,7 +160,7 @@ function App({ initialLanguage }) {
                   <Route path="/aionlabs" element={<AionLabs />} />
                   <Route
                     path="/sites"
-                    element={renderPrivateRoute(<Sites simplified={false} />, {
+                    element={renderPrivateRoute(<InternalRoutePlaceholder />, {
                       title: 'Vista utilitaria | Elier Loya',
                       description: 'Vista interna con acceso controlado y sin indexacion publica.'
                     })}

--- a/my-app/src/components/InternalRoutePlaceholder.jsx
+++ b/my-app/src/components/InternalRoutePlaceholder.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+function InternalRoutePlaceholder() {
+  return (
+    <section
+      aria-labelledby="internal-route-placeholder-title"
+      style={{
+        minHeight: '60vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '4rem 1.5rem',
+      }}
+    >
+      <div
+        style={{
+          width: '100%',
+          maxWidth: '640px',
+          textAlign: 'center',
+          padding: '2.5rem 2rem',
+          borderRadius: '1rem',
+          background: 'var(--color-bg-2)',
+          border: '1px solid var(--color-border, rgba(255, 255, 255, 0.08))',
+          boxShadow: '0 18px 40px rgba(0, 0, 0, 0.12)',
+        }}
+      >
+        <h1 id="internal-route-placeholder-title">Espacio no disponible</h1>
+        <p style={{ margin: '1rem 0 1.75rem' }}>
+          Esta vista no está disponible públicamente.
+        </p>
+        <Link to="/" className="hero-button">
+          Volver al inicio
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export default InternalRoutePlaceholder;

--- a/my-app/src/internalRoutePlaceholder.test.js
+++ b/my-app/src/internalRoutePlaceholder.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import InternalRoutePlaceholder from './components/InternalRoutePlaceholder';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+it('renders the generic unavailable placeholder without sensitive or utility content', async () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(
+      <MemoryRouter>
+        <InternalRoutePlaceholder />
+      </MemoryRouter>
+    );
+  });
+
+  try {
+    expect(container.textContent).toContain('Espacio no disponible');
+    expect(container.textContent).toContain('Esta vista no está disponible públicamente.');
+    expect(container.textContent).toContain('Volver al inicio');
+    expect(container.textContent).not.toContain('Credenciales de acceso');
+    expect(container.textContent).not.toContain('95%');
+    expect(container.textContent).not.toContain('Cómo la IA está Transformando el E-commerce');
+    expect(container.querySelector('a[href="/"]')).not.toBeNull();
+    expect(container.querySelector('a[target="_blank"]')).toBeNull();
+  } finally {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  }
+});

--- a/my-app/src/privateRouteExposure.test.js
+++ b/my-app/src/privateRouteExposure.test.js
@@ -114,6 +114,17 @@ describe('private route exposure hardening', () => {
     expect(source).not.toContain('www.elelier.com');
   });
 
+  it('declares a reusable placeholder for visually closed private and utilitarian routes', () => {
+    const placeholderPath = path.join(__dirname, 'components/InternalRoutePlaceholder.jsx');
+
+    expect(fs.existsSync(placeholderPath)).toBe(true);
+
+    const source = fs.readFileSync(placeholderPath, 'utf8');
+    expect(source).toContain('Espacio no disponible');
+    expect(source).toContain('Esta vista no está disponible públicamente.');
+    expect(source).toContain('Volver al inicio');
+  });
+
   it('wraps every approved private route from App.js without touching core public routes', () => {
     const source = fs.readFileSync(path.join(__dirname, 'App.js'), 'utf8');
 
@@ -127,6 +138,11 @@ describe('private route exposure hardening', () => {
     expect(source).toContain('path="/hero-banner"');
     expect(source).toContain('path="/entradas/2408_IA_Transforma_ecommerce"');
     expect(source).toContain('PrivateRouteSEO');
+    expect(source).toContain('InternalRoutePlaceholder');
+    expect(source).not.toContain('renderPrivateRoute(<ClientDemo />');
+    expect(source).not.toContain('renderPrivateRoute(<MockupRedirect />');
+    expect(source).not.toContain('renderPrivateRoute(<Sites simplified={false} />');
+    expect(source).not.toContain('renderPrivateRoute(<Entrada />');
     expect(source).not.toContain('<Route path="/" element={<><PrivateRouteSEO');
     expect(source).not.toContain('<Route path="/portafolio" element={<><PrivateRouteSEO');
     expect(source).not.toContain('<Route path="/sobre-mi" element={<><PrivateRouteSEO');


### PR DESCRIPTION
## Resumen
- reemplaza el render público de /client-demo, /mockup/:id, /sites y /entradas/2408_IA_Transforma_ecommerce por un placeholder genérico
- conserva la metadata privada existente con noindex,nofollow,noarchive y canonical apex
- agrega cobertura de pruebas para el placeholder y para evitar que esas rutas vuelvan a montar sus componentes expuestos

## Verificación
- npm test -- --runInBand --watchAll=false
- npm run build
- git diff --check
- QA local en http://127.0.0.1:3000 y build local en http://127.0.0.1:5001

## Fuera de alcance
- sin deploy
- sin cambios a sitemap.xml o robots.txt
- sin cambios a endpoints o backend