### PR TITLE
Iteración 15: política conservadora de indexación SEO

### DIFF
--- a/my-app/public/sitemap.xml
+++ b/my-app/public/sitemap.xml
@@ -6,36 +6,6 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://elelier.com/portafolio</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://elelier.com/sobre-mi</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://elelier.com/servicios</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://elelier.com/contacto</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://elelier.com/blog</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://elelier.com/aionlabs</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
     <loc>https://elelier.com/privacy-policy</loc>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -7,6 +7,7 @@ import { FaArrowUp } from 'react-icons/fa';
 import './styles/App.css';
 import './styles/components/UxSmallFixes.css';
 import SEO from './components/SEO';
+import RouteSEO from './components/RouteSEO';
 import Navegacion from './components/Navegacion';
 import HeroBanner from './components/HeroBanner';
 import Soluciones from './components/Soluciones';
@@ -31,6 +32,7 @@ import PrivateRouteSEO from './components/PrivateRouteSEO';
 import InternalRoutePlaceholder from './components/InternalRoutePlaceholder';
 import { initializeTheme } from './components/utils/themeUtils';
 import { getMotionAwareScrollBehavior, loadExternalScripts } from './components/utils/generalUtils';
+import { getRouteSeoPolicy } from './config/routeSeoPolicy';
 import './utils/testGemini';
 
 if (process.env.NODE_ENV === 'development') {
@@ -62,6 +64,7 @@ function App({ initialLanguage }) {
     '--section-bg-start': homeSectionPalette[index % homeSectionPalette.length],
     '--section-bg-end': homeSectionPalette[(index + 1) % homeSectionPalette.length],
   });
+  const homeSeoPolicy = getRouteSeoPolicy('/');
 
   useEffect(() => {
     initializeTheme();
@@ -79,6 +82,13 @@ function App({ initialLanguage }) {
     </>
   );
 
+  const renderPublicAliasRoute = (element, seoProps) => (
+    <>
+      <RouteSEO {...seoProps} />
+      {element}
+    </>
+  );
+
   return (
     <HelmetProvider>
       <LanguageProvider initialLanguage={initialLanguage}>
@@ -87,8 +97,8 @@ function App({ initialLanguage }) {
             <div className="App">
               <SettingsMenu />
               <SEO
-                title="Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya"
-                description="Transformo procesos complicados en soluciones que realmente funcionan. Especialista en operaciones, producto digital e IA aplicada."
+                title={homeSeoPolicy?.title}
+                description={homeSeoPolicy?.description}
               />
               <Navegacion />
               <Suspense fallback={<div>Loading...</div>}>
@@ -108,10 +118,38 @@ function App({ initialLanguage }) {
                       description: 'Vista interna con acceso controlado y sin indexacion publica.'
                     })}
                   />
-                  <Route path="/portafolio" element={<Portafolio />} />
-                  <Route path="/sobre-mi" element={<SobreMi />} />
-                  <Route path="/servicios" element={<Servicios />} />
-                  <Route path="/blog" element={<Blog />} />
+                  <Route
+                    path="/portafolio"
+                    element={renderPublicAliasRoute(<Portafolio />, {
+                      route: '/portafolio',
+                      title: getRouteSeoPolicy('/portafolio')?.title,
+                      description: getRouteSeoPolicy('/portafolio')?.description,
+                    })}
+                  />
+                  <Route
+                    path="/sobre-mi"
+                    element={renderPublicAliasRoute(<SobreMi />, {
+                      route: '/sobre-mi',
+                      title: getRouteSeoPolicy('/sobre-mi')?.title,
+                      description: getRouteSeoPolicy('/sobre-mi')?.description,
+                    })}
+                  />
+                  <Route
+                    path="/servicios"
+                    element={renderPublicAliasRoute(<Servicios />, {
+                      route: '/servicios',
+                      title: getRouteSeoPolicy('/servicios')?.title,
+                      description: getRouteSeoPolicy('/servicios')?.description,
+                    })}
+                  />
+                  <Route
+                    path="/blog"
+                    element={renderPublicAliasRoute(<Blog />, {
+                      route: '/blog',
+                      title: getRouteSeoPolicy('/blog')?.title,
+                      description: getRouteSeoPolicy('/blog')?.description,
+                    })}
+                  />
                   <Route
                     path="/entradas/2408_IA_Transforma_ecommerce"
                     element={renderPrivateRoute(<InternalRoutePlaceholder />, {
@@ -119,7 +157,14 @@ function App({ initialLanguage }) {
                       description: 'Contenido interno con acceso controlado y sin indexacion publica.'
                     })}
                   />
-                  <Route path="/contacto" element={<Contacto />} />
+                  <Route
+                    path="/contacto"
+                    element={renderPublicAliasRoute(<Contacto />, {
+                      route: '/contacto',
+                      title: getRouteSeoPolicy('/contacto')?.title,
+                      description: getRouteSeoPolicy('/contacto')?.description,
+                    })}
+                  />
                   <Route
                     path="/cotizacion/:id"
                     element={renderPrivateRoute(<ExternalRedirect />, {
@@ -157,7 +202,14 @@ function App({ initialLanguage }) {
                   />
                   <Route path="/privacy-policy" element={<PrivacyPolicy />} />
                   <Route path="/terms-of-service" element={<TermsOfService />} />
-                  <Route path="/aionlabs" element={<AionLabs />} />
+                  <Route
+                    path="/aionlabs"
+                    element={renderPublicAliasRoute(<AionLabs />, {
+                      route: '/aionlabs',
+                      title: getRouteSeoPolicy('/aionlabs')?.title,
+                      description: getRouteSeoPolicy('/aionlabs')?.description,
+                    })}
+                  />
                   <Route
                     path="/sites"
                     element={renderPrivateRoute(<InternalRoutePlaceholder />, {

--- a/my-app/src/appRuntimeHead.test.js
+++ b/my-app/src/appRuntimeHead.test.js
@@ -1,0 +1,254 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+jest.unmock('react-helmet-async');
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import SEO from './components/SEO';
+import RouteSEO from './components/RouteSEO';
+import { LanguageProvider } from './contexts/LanguageContext';
+import PrivacyPolicy from './pages/PrivacyPolicy';
+import TermsOfService from './pages/TermsOfService';
+import { getRouteSeoPolicy } from './config/routeSeoPolicy';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const resetHead = () => {
+  document.title = '';
+  document.documentElement.removeAttribute('lang');
+  document.head
+    .querySelectorAll(
+      'meta[charset],meta[name="viewport"],meta[name="description"],meta[name="keywords"],meta[name="robots"],meta[property^="og:"],meta[name^="twitter:"],link[rel="canonical"]'
+    )
+    .forEach((node) => node.remove());
+};
+
+const readHeadState = () => ({
+  title: document.title,
+  robots: document.head.querySelector('meta[name="robots"]')?.getAttribute('content'),
+  canonical: document.head.querySelector('link[rel="canonical"]')?.getAttribute('href'),
+});
+
+const waitForCondition = async (assertion, timeoutMs = 3000) => {
+  const startedAt = Date.now();
+
+  while (true) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw error;
+      }
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+    }
+  }
+};
+
+const HomeShell = () => {
+  const homePolicy = getRouteSeoPolicy('/');
+
+  return (
+    <>
+      <SEO title={homePolicy.title} description={homePolicy.description} />
+      <section>
+        <h1>Transformo procesos complicados en soluciones que realmente funcionan.</h1>
+      </section>
+    </>
+  );
+};
+
+const routeCases = {
+  '/': {
+    title: getRouteSeoPolicy('/').title,
+    robots: 'index,follow',
+    canonical: 'https://elelier.com/',
+    visibleText: 'Transformo procesos complicados en soluciones que realmente funcionan.',
+    element: <HomeShell />,
+  },
+  '/privacy-policy': {
+    title: 'Política de Privacidad | Elier Loya',
+    robots: 'index,follow',
+    canonical: 'https://elelier.com/privacy-policy',
+    visibleText: 'Política de Privacidad',
+    element: <PrivacyPolicy />,
+  },
+  '/terms-of-service': {
+    title: 'Condiciones del Servicio | Elier Loya',
+    robots: 'index,follow',
+    canonical: 'https://elelier.com/terms-of-service',
+    visibleText: 'Condiciones del Servicio',
+    element: <TermsOfService />,
+  },
+  '/portafolio': {
+    title: 'Carrera profesional | Elier Loya',
+    robots: 'noindex,follow',
+    canonical: 'https://elelier.com/',
+    visibleText: 'Carrera profesional',
+    element: (
+      <>
+        <RouteSEO route="/portafolio" />
+        <section>
+          <h1>Carrera profesional</h1>
+          <p>Trayectoria profesional visible.</p>
+        </section>
+      </>
+    ),
+  },
+  '/sobre-mi': {
+    title: 'Sobre Mí | Elier Loya',
+    robots: 'noindex,follow',
+    canonical: 'https://elelier.com/',
+    visibleText: 'SOBRE MÍ',
+    element: (
+      <>
+        <RouteSEO route="/sobre-mi" />
+        <section>
+          <h1>SOBRE MÍ</h1>
+          <p>Perfil profesional visible.</p>
+        </section>
+      </>
+    ),
+  },
+  '/servicios': {
+    title: 'Cómo trabajo | Elier Loya',
+    robots: 'noindex,follow',
+    canonical: 'https://elelier.com/',
+    visibleText: 'Cómo trabajo',
+    element: (
+      <>
+        <RouteSEO route="/servicios" />
+        <section>
+          <h1>Cómo trabajo</h1>
+          <p>Método de colaboración visible.</p>
+        </section>
+      </>
+    ),
+  },
+  '/contacto': {
+    title: 'Contacto | Elier Loya',
+    robots: 'noindex,follow',
+    canonical: 'https://elelier.com/',
+    visibleText: 'Cuéntame qué quieres mejorar',
+    element: (
+      <>
+        <RouteSEO route="/contacto" />
+        <section>
+          <h1>Cuéntame qué quieres mejorar</h1>
+          <p>Contacto visible.</p>
+        </section>
+      </>
+    ),
+  },
+  '/blog': {
+    title: 'Blog | Elier Loya',
+    robots: 'noindex,follow',
+    canonical: 'https://elelier.com/',
+    visibleText: 'Blog',
+    element: (
+      <>
+        <RouteSEO route="/blog" />
+        <section>
+          <h1>Blog</h1>
+          <p>Contenido editorial visible.</p>
+        </section>
+      </>
+    ),
+  },
+  '/aionlabs': {
+    title: 'Aion Labs | Aion × Elier',
+    robots: 'noindex,follow',
+    canonical: 'https://elelier.com/',
+    visibleText: 'Aion',
+    element: (
+      <>
+        <RouteSEO route="/aionlabs" />
+        <section>
+          <h1>Aion</h1>
+          <p>Espacio experimental visible.</p>
+        </section>
+      </>
+    ),
+  },
+};
+
+const renderRouteTree = async (pathname) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const route = routeCases[pathname];
+
+  await act(async () => {
+    root.render(
+      <HelmetProvider>
+        <LanguageProvider>
+          <MemoryRouter initialEntries={[pathname]}>
+            <Routes>
+              <Route
+                path="*"
+                element={
+                  <>
+                    <SEO
+                      title={getRouteSeoPolicy('/').title}
+                      description={getRouteSeoPolicy('/').description}
+                    />
+                    {route.element}
+                  </>
+                }
+              />
+            </Routes>
+          </MemoryRouter>
+        </LanguageProvider>
+      </HelmetProvider>
+    );
+  });
+
+  const cleanup = async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    resetHead();
+    document.body.innerHTML = '';
+  };
+
+  return { cleanup, route, container };
+};
+
+describe('App runtime head on real route tree', () => {
+  afterEach(() => {
+    resetHead();
+    document.body.innerHTML = '';
+  });
+
+  it.each([
+    '/',
+    '/privacy-policy',
+    '/terms-of-service',
+    '/portafolio',
+    '/sobre-mi',
+    '/servicios',
+    '/contacto',
+    '/blog',
+    '/aionlabs',
+  ])('hydrates the expected head for %s', async (pathname) => {
+    const { cleanup, route, container } = await renderRouteTree(pathname);
+
+    try {
+      await waitForCondition(() => {
+        expect(readHeadState()).toEqual({
+          title: route.title,
+          robots: route.robots,
+          canonical: route.canonical,
+        });
+      });
+      expect(container.textContent).toContain(route.visibleText);
+      expect(container.textContent).not.toContain('Esta vista no está disponible públicamente.');
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/my-app/src/components/AionLabs.jsx
+++ b/my-app/src/components/AionLabs.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { FaArrowRight, FaBrain, FaBolt, FaBridgeWater, FaCircleCheck } from 'react-icons/fa6';
-import SEO from './SEO';
 import { useLanguage } from '../contexts/LanguageContext';
 import '../styles/components/AionLabs.css';
 
@@ -10,12 +9,6 @@ function AionLabs() {
 
   const content = {
     es: {
-      seo: {
-        title: 'Aion Labs | Aion × Elier',
-        description: 'Un espacio para presentar a Aion: cómo piensa, cómo hace equipo con EL y hacia dónde podría evolucionar esta colaboración.',
-        keywords: 'Aion Labs, Aion, asistente digital, colaboración humano AI, elelier',
-        imageAlt: 'Aion Labs, espacio experimental dentro de elelier'
-      },
       badge: 'Aion Labs · Experimental space',
       kicker: 'Mitad chispa, mitad sistema.',
       heroTitle: 'Soy ',
@@ -68,12 +61,6 @@ function AionLabs() {
       ctaPrimary: 'Volver al portafolio'
     },
     en: {
-      seo: {
-        title: 'Aion Labs | Aion × Elier',
-        description: 'A space to introduce Aion: how it thinks, how it works with EL, and where this collaboration could evolve next.',
-        keywords: 'Aion Labs, Aion, digital assistant, human AI collaboration, elelier',
-        imageAlt: 'Aion Labs, experimental space inside elelier'
-      },
       badge: 'Aion Labs · Experimental space',
       kicker: 'Half spark, half system.',
       heroTitle: 'I am ',
@@ -131,15 +118,6 @@ function AionLabs() {
 
   return (
     <main className="aion-labs-page">
-      <SEO
-        title={t.seo.title}
-        description={t.seo.description}
-        pathname="/aionlabs"
-        keywords={t.seo.keywords}
-        imageAlt={t.seo.imageAlt}
-        locale={language === 'en' ? 'en_US' : 'es_MX'}
-      />
-
       <section className="aion-hero">
         <div className="aion-hero__glow aion-hero__glow--one" />
         <div className="aion-hero__glow aion-hero__glow--two" />

--- a/my-app/src/components/RouteSEO.js
+++ b/my-app/src/components/RouteSEO.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import SEO from './SEO';
+import { getRouteSeoPolicy } from '../config/routeSeoPolicy';
+
+function RouteSEO({
+  route,
+  title,
+  description,
+  pathname,
+  robots,
+  keywords,
+  image,
+  imageAlt,
+  locale,
+  type,
+}) {
+  const policy = getRouteSeoPolicy(route) || {};
+
+  return (
+    <SEO
+      title={title || policy.title}
+      description={description || policy.description}
+      pathname={pathname || policy.canonicalPath || route}
+      robots={robots || policy.robots}
+      keywords={keywords}
+      image={image}
+      imageAlt={imageAlt}
+      locale={locale}
+      type={type}
+    />
+  );
+}
+
+export default RouteSEO;

--- a/my-app/src/components/SEO.js
+++ b/my-app/src/components/SEO.js
@@ -15,6 +15,7 @@ function SEO({
   title,
   description,
   pathname,
+  canonicalPath,
   image = DEFAULT_OG_IMAGE,
   type = 'website',
   robots = 'index,follow',
@@ -24,7 +25,7 @@ function SEO({
 }) {
   const location = useLocation();
   const currentPath = pathname || location.pathname || '/';
-  const canonicalUrl = buildUrl(currentPath);
+  const canonicalUrl = buildUrl(canonicalPath || currentPath);
 
   return (
     <Helmet>

--- a/my-app/src/config/routeSeoPolicy.js
+++ b/my-app/src/config/routeSeoPolicy.js
@@ -1,0 +1,89 @@
+export const INDEXABLE_SITEMAP_PATHS = ['/', '/privacy-policy', '/terms-of-service'];
+
+export const ROUTE_SEO_POLICY = {
+  '/': {
+    title: 'Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya',
+    description:
+      'Transformo procesos complicados en soluciones que realmente funcionan. Especialista en operaciones, producto digital e IA aplicada.',
+    canonicalPath: '/',
+    robots: 'index,follow',
+  },
+  '/portafolio': {
+    title: 'Carrera profesional | Elier Loya',
+    description:
+      'Una trayectoria construida entre operación, producto digital y soluciones que generan resultados reales.',
+    canonicalPath: '/',
+    robots: 'noindex,follow',
+  },
+  '/sobre-mi': {
+    title: 'Sobre Mí | Elier Loya',
+    description:
+      'Combino criterio operativo, pensamiento de producto y ejecución técnica para sacar proyectos de la maraña estratégica o tecnológica.',
+    canonicalPath: '/',
+    robots: 'noindex,follow',
+  },
+  '/servicios': {
+    title: 'Cómo trabajo | Elier Loya',
+    description: 'Filtro sin rodeos: trabajo mejor con retos acotados, métricas claras y entregas visibles.',
+    canonicalPath: '/',
+    robots: 'noindex,follow',
+  },
+  '/contacto': {
+    title: 'Contacto | Elier Loya',
+    description: 'Cuéntame qué quieres mejorar, automatizar, simplificar, digitalizar o crear.',
+    canonicalPath: '/',
+    robots: 'noindex,follow',
+  },
+  '/blog': {
+    title: 'Blog | Elier Loya',
+    description:
+      'Blog profesional de elelier.com con artículos y actualizaciones de tecnología, digitalización y más.',
+    canonicalPath: '/',
+    robots: 'noindex,follow',
+  },
+  '/aionlabs': {
+    title: 'Aion Labs | Aion × Elier',
+    description:
+      'Un espacio experimental para presentar a Aion, cómo trabaja con EL y hacia dónde puede evolucionar esta colaboración.',
+    canonicalPath: '/',
+    robots: 'noindex,follow',
+  },
+  '/privacy-policy': {
+    title: 'Política de Privacidad | Elier Loya',
+    canonicalPath: '/privacy-policy',
+    robots: 'index,follow',
+  },
+  '/terms-of-service': {
+    title: 'Condiciones del Servicio | Elier Loya',
+    canonicalPath: '/terms-of-service',
+    robots: 'index,follow',
+  },
+  '/tarifas-2024': {
+    canonicalPath: '/',
+    robots: 'noindex,nofollow,noarchive',
+  },
+  '/hero-banner': {
+    canonicalPath: '/',
+    robots: 'noindex,nofollow,noarchive',
+  },
+  '/client-demo': {
+    canonicalPath: '/',
+    robots: 'noindex,nofollow,noarchive',
+  },
+  '/sites': {
+    canonicalPath: '/',
+    robots: 'noindex,nofollow,noarchive',
+  },
+  '/admin/leads': {
+    canonicalPath: '/',
+    robots: 'noindex,nofollow,noarchive',
+  },
+  '/entradas/2408_IA_Transforma_ecommerce': {
+    canonicalPath: '/',
+    robots: 'noindex,nofollow,noarchive',
+  },
+};
+
+export function getRouteSeoPolicy(pathname) {
+  return ROUTE_SEO_POLICY[pathname] || null;
+}

--- a/my-app/src/pages/PrivacyPolicy.jsx
+++ b/my-app/src/pages/PrivacyPolicy.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import SEO from '../components/SEO';
+import { getRouteSeoPolicy } from '../config/routeSeoPolicy';
 import '../styles/LegalPages.css';
 
 const OG_IMAGE = 'https://elelier.com/static/media/eleliercom.ced5bb90383175580555.png';
@@ -221,6 +222,7 @@ const content = {
 function PrivacyPolicy() {
   const { language } = useLanguage();
   const page = content[language] || content.es;
+  const routePolicy = getRouteSeoPolicy('/privacy-policy');
 
   return (
     <main className="legal-page">
@@ -228,6 +230,8 @@ function PrivacyPolicy() {
         title={page.seoTitle}
         description={page.seoDescription}
         pathname={page.seoPath}
+        canonicalPath={routePolicy?.canonicalPath}
+        robots={routePolicy?.robots}
         keywords={page.seoKeywords}
         image={OG_IMAGE}
         imageAlt={page.title}

--- a/my-app/src/pages/TermsOfService.jsx
+++ b/my-app/src/pages/TermsOfService.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useLanguage } from '../contexts/LanguageContext';
 import SEO from '../components/SEO';
+import { getRouteSeoPolicy } from '../config/routeSeoPolicy';
 import '../styles/LegalPages.css';
 
 const OG_IMAGE = 'https://elelier.com/static/media/eleliercom.ced5bb90383175580555.png';
@@ -191,6 +192,7 @@ const content = {
 function TermsOfService() {
   const { language } = useLanguage();
   const page = content[language] || content.es;
+  const routePolicy = getRouteSeoPolicy('/terms-of-service');
 
   return (
     <main className="legal-page">
@@ -198,6 +200,8 @@ function TermsOfService() {
         title={page.seoTitle}
         description={page.seoDescription}
         pathname={page.seoPath}
+        canonicalPath={routePolicy?.canonicalPath}
+        robots={routePolicy?.robots}
         keywords={page.seoKeywords}
         image={OG_IMAGE}
         imageAlt={page.title}

--- a/my-app/src/routeSeoPolicy.test.js
+++ b/my-app/src/routeSeoPolicy.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+jest.mock('react-helmet-async');
+import RouteSEO from './components/RouteSEO';
+import SEO from './components/SEO';
+import { getRouteSeoPolicy, INDEXABLE_SITEMAP_PATHS } from './config/routeSeoPolicy';
+import { readHeadState, renderRoute } from './seoHeadRouteTestUtils';
+
+describe('route SEO policy', () => {
+  it('keeps the sitemap limited to the approved indexable paths', () => {
+    expect(INDEXABLE_SITEMAP_PATHS).toEqual(['/', '/privacy-policy', '/terms-of-service']);
+    expect(getRouteSeoPolicy('/portafolio')).toMatchObject({
+      canonicalPath: '/',
+      robots: 'noindex,follow',
+    });
+    expect(getRouteSeoPolicy('/privacy-policy')).toMatchObject({
+      canonicalPath: '/privacy-policy',
+      robots: 'index,follow',
+    });
+  });
+
+  it.each([
+    ['/portafolio', 'Carrera profesional | Elier Loya'],
+    ['/sobre-mi', 'Sobre Mí | Elier Loya'],
+    ['/servicios', 'Cómo trabajo | Elier Loya'],
+    ['/contacto', 'Contacto | Elier Loya'],
+    ['/blog', 'Blog | Elier Loya'],
+    ['/aionlabs', 'Aion Labs | Aion × Elier'],
+  ])('renders %s as a noindex alias with canonical home', async (route, title) => {
+    const cleanup = await renderRoute({
+      pathname: route,
+      routePath: route,
+      element: (
+        <>
+          <RouteSEO route={route} />
+          <section>{route}</section>
+        </>
+      ),
+    });
+
+    try {
+      expect(readHeadState()).toEqual({
+        title,
+        robots: 'noindex,follow',
+        canonical: 'https://elelier.com/',
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it.each([
+    ['/privacy-policy', 'Política de Privacidad | Elier Loya', 'index,follow'],
+    ['/terms-of-service', 'Condiciones del Servicio | Elier Loya', 'index,follow'],
+  ])('keeps %s indexable with its own canonical path', async (route, title, robots) => {
+    const cleanup = await renderRoute({
+      pathname: route,
+      routePath: route,
+      element: (
+        <SEO
+          title={title}
+          description={`${route} page`}
+          pathname={route}
+          canonicalPath={route}
+          robots={robots}
+        />
+      ),
+    });
+
+    try {
+      expect(readHeadState()).toEqual({
+        title,
+        robots,
+        canonical: `https://elelier.com${route}`,
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('keeps home indexable with canonical https://elelier.com/', async () => {
+    const cleanup = await renderRoute({
+      pathname: '/',
+      routePath: '/',
+      element: (
+        <SEO
+          title="Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya"
+          description="Transformo procesos complicados en soluciones que realmente funcionan. Especialista en operaciones, producto digital e IA aplicada."
+        />
+      ),
+    });
+
+    try {
+      expect(readHeadState()).toEqual({
+        title: 'Transformo procesos complicados en soluciones que realmente funcionan. | Elier Loya',
+        robots: 'index,follow',
+        canonical: 'https://elelier.com/',
+      });
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/my-app/src/staticSeoArtifacts.test.js
+++ b/my-app/src/staticSeoArtifacts.test.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { INDEXABLE_SITEMAP_PATHS } = require('./config/routeSeoPolicy');
 
 const publicDir = path.resolve(__dirname, '../public');
 const robotsPath = path.join(publicDir, 'robots.txt');
@@ -25,17 +26,7 @@ describe('static SEO artifacts', () => {
 
     expect(sitemap).not.toContain('https://www.elelier.com');
     expect(sitemap).not.toContain('<lastmod>');
-    expect(extractSitemapPaths(sitemap)).toEqual([
-      '/',
-      '/portafolio',
-      '/sobre-mi',
-      '/servicios',
-      '/contacto',
-      '/blog',
-      '/aionlabs',
-      '/privacy-policy',
-      '/terms-of-service'
-    ]);
+    expect(extractSitemapPaths(sitemap)).toEqual(INDEXABLE_SITEMAP_PATHS);
     expect(sitemap).not.toContain('/proyecto/');
     expect(sitemap).not.toContain('/admin/leads');
     expect(sitemap).not.toContain('/client-demo');


### PR DESCRIPTION
Resumen\n- Centraliza la política SEO de rutas en src/config/routeSeoPolicy.js.\n- Mantiene /, /privacy-policy y /terms-of-service como únicas rutas indexables en sitemap.\n- Deja /portafolio, /sobre-mi, /servicios, /contacto, /blog y /aionlabs accesibles pero 
oindex con canonical a home.\n- Mantiene rutas privadas/utilitarias fuera del sitemap y con canonical home.\n\nValidación\n- 
pm test -- --runInBand --watchAll=false\n- 
pm run build\n- git diff --check\n\nNotas\n- No se hizo deploy.\n- No se hizo merge.\n- PR creado como draft según instrucción.