### PR TITLE
Fix mobile Contacto anchor offset

### DIFF
--- a/my-app/src/components/Contacto.js
+++ b/my-app/src/components/Contacto.js
@@ -123,7 +123,7 @@ function Contacto({ style }) {
     <AnimatedSection
       id="contacto"
       className="contacto"
-      style={{ scrollMarginTop: '96px', ...style }}
+      style={{ scrollMarginTop: '60px', ...style }}
       {...(prefersReducedMotion
         ? {}
         : {


### PR DESCRIPTION
## Summary
- Fixes the Contacto anchor/focus visual offset on mobile by aligning the section scroll margin to the fixed header height.
- Keeps Contacto copy, CTAs, SEO, routes, analytics, form behavior, and section structure unchanged.

## Cause
Contacto already had an inline `scrollMarginTop` of `96px`, while the fixed header is `60px` tall. When `scrollIntoView()` ran from the mobile menu or desktop nav, the browser placed Contacto 96px below the viewport top, leaving roughly 36px of the previous section visible below the header.

## Change
- Changed Contacto `scrollMarginTop` from `96px` to `60px` in `src/components/Contacto.js`.

## Validation
- `npm test -- --runInBand --watchAll=false` -> 31 suites passed, 95 tests passed.
- `npm run build` -> production build compiled successfully and generated static routes for 13 routes.
- `git diff --check` -> passed; only expected Windows LF/CRLF warning.
- `git restore src/config/hashedPasscodes.js` -> generated build noise restored.
- `git status --short` before commit -> only `src/components/Contacto.js` modified.

## Visual QA
| viewport | idioma | tema | acción | esperado | observado | estado |
|---|---|---|---|---|---|---|
| 390x844 | inglés | oscuro | abrir menú móvil y tocar `Let’s talk about your challenge` | Contacto inicia limpio bajo header, sin franja previa | `contactoTop` ~60px, header 60px, elemento bajo header: `contacto`, sin console errors | Pass |
| 375x812 | español | oscuro | abrir menú móvil y tocar `Hablemos de tu reto` | Sin franja visual previa y sin overflow horizontal | `contactoTop` ~60px, elemento bajo header: `contacto`, `overflowX: false` | Pass |
| 1440x900 | español | oscuro | nav desktop hacia Contacto | Contacto no queda tapado por header ni crea separación rara | `contactoTop` ~60px, elemento bajo header: `contacto`, `overflowX: false` | Pass |
| 1440x900 | español | oscuro | abrir `/contacto` directo | Contacto renderiza limpio en ruta directa | sección en viewport, heading visible bajo header, `overflowX: false` | Pass |

## Residual Risk
- QA local fue en Chromium/in-app browser; el reporte original fue Android Chrome real. El ajuste usa CSS estándar `scroll-margin-top`, por lo que el riesgo residual principal es variación menor de viewport/browser chrome en dispositivo físico.

Draft PR; do not mark ready, merge, or deploy.
