### PR TITLE
Iteration 17C: fix Cloudflare Pages deep route rewrites

### DIFF
--- a/my-app/CLOUDFLARE_PAGES.md
+++ b/my-app/CLOUDFLARE_PAGES.md
@@ -25,6 +25,10 @@ Do not paste real secret values into this repository.
 
 Keep GitHub Pages in place as the rollback path until the Cloudflare Pages production deployment is validated on the real domain. DNS cutover remains out of scope for this change.
 
+## Deep-route rewrite note
+
+The first Cloudflare Pages smoke showed that wildcard prefix rules did not resolve the dynamic deep links. The `_redirects` contract therefore uses explicit rules and named placeholders for the React routes, while leaving prerendered routes and assets untouched.
+
 ## Smoke checklist for `*.pages.dev`
 
 1. Load `/` and confirm the home sections render normally.

--- a/my-app/public/_redirects
+++ b/my-app/public/_redirects
@@ -1,7 +1,18 @@
 # Cloudflare Pages SPA fallback for dynamic React routes only.
 # Static prerendered routes and assets should continue serving normally.
-/proyecto/* /index.html 200
-/cotizacion/* /index.html 200
-/mockup/* /index.html 200
-/admin/* /index.html 200
-/entradas/* /index.html 200
+
+# Dynamic/private SPA routes
+/proyecto/:token /index.html 200
+/proyecto/:token/ /index.html 200
+/cotizacion/:id /index.html 200
+/cotizacion/:id/ /index.html 200
+/mockup/:id /index.html 200
+/mockup/:id/ /index.html 200
+
+# Admin utility route
+/admin/leads /index.html 200
+/admin/leads/ /index.html 200
+
+# Private editorial route
+/entradas/:slug /index.html 200
+/entradas/:slug/ /index.html 200

--- a/my-app/src/staticSeoArtifacts.test.js
+++ b/my-app/src/staticSeoArtifacts.test.js
@@ -7,11 +7,16 @@ const robotsPath = path.join(publicDir, 'robots.txt');
 const sitemapPath = path.join(publicDir, 'sitemap.xml');
 const redirectsPath = path.join(publicDir, '_redirects');
 const expectedDynamicRedirects = [
-  '/proyecto/* /index.html 200',
-  '/cotizacion/* /index.html 200',
-  '/mockup/* /index.html 200',
-  '/admin/* /index.html 200',
-  '/entradas/* /index.html 200',
+  '/proyecto/:token /index.html 200',
+  '/proyecto/:token/ /index.html 200',
+  '/cotizacion/:id /index.html 200',
+  '/cotizacion/:id/ /index.html 200',
+  '/mockup/:id /index.html 200',
+  '/mockup/:id/ /index.html 200',
+  '/admin/leads /index.html 200',
+  '/admin/leads/ /index.html 200',
+  '/entradas/:slug /index.html 200',
+  '/entradas/:slug/ /index.html 200',
 ];
 
 function read(filePath) {
@@ -57,6 +62,11 @@ describe('static SEO artifacts', () => {
       expect(redirects).toContain(rule);
     }
 
+    expect(redirects).not.toContain('/proyecto/* /index.html 200');
+    expect(redirects).not.toContain('/cotizacion/* /index.html 200');
+    expect(redirects).not.toContain('/mockup/* /index.html 200');
+    expect(redirects).not.toContain('/admin/* /index.html 200');
+    expect(redirects).not.toContain('/entradas/* /index.html 200');
     expect(redirects).not.toContain('/portafolio/* /index.html 200');
     expect(redirects).not.toContain('/sobre-mi/* /index.html 200');
     expect(redirects).not.toContain('/servicios/* /index.html 200');


### PR DESCRIPTION
## Summary

- Replaced the five broad Cloudflare Pages wildcard rewrites with explicit named-placeholder rules for dynamic routes and explicit trailing-slash variants.
- Added scoped admin and editorial route rewrites without adding a global `/* /index.html 200` catch-all.
- Updated the static artifact regression test and documented the first Cloudflare Pages smoke finding.

## Root cause

The first `elelier.pages.dev` smoke returned 404 for deep dynamic/private routes even though static routes and assets worked. The previous prefix wildcard rules were not resolving those deep links in the observed Pages environment.

## Validation

- `npm test -- --runInBand --watchAll=false`: 31 suites, 96 tests passed.
- `npm run build`: passed.
- `build/_redirects`: exists, contains all ten explicit rules, and contains no global catch-all.
- `git diff --check`: passed.
- `src/config/hashedPasscodes.js`: restored and excluded from the PR.

## Scope

No DNS changes, Cloudflare dashboard changes, deploy, merge, GitHub Pages removal, CNAME changes, sitemap changes, or robots changes.
GitHub Pages remains the rollback path.