### PR TITLE
docs: close out cloudflare pages migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@
 
 ### Herramientas de Desarrollo
 - **Git & GitHub**: Control de versiones
-- **GitHub Pages**: Alojamiento
+- **Cloudflare Pages**: Hosting productivo actual
+- **GitHub Pages**: Ruta legacy/manual de rollback
 - **NPM**: Gestión de paquetes
 
 ## Características
@@ -86,7 +87,7 @@
 
 ## Despliegue
 
-El portfolio está desplegado en GitHub Pages y accesible en [elelier.com](https://www.elelier.com).
+El portfolio tiene como hosting productivo actual Cloudflare Pages y está accesible en [elelier.com](https://elelier.com). GitHub Pages se conserva únicamente como ruta legacy/manual de rollback.
 
 ### Configuración de Producción
 - Dominio personalizado configurado

--- a/my-app/CLOUDFLARE_PAGES.md
+++ b/my-app/CLOUDFLARE_PAGES.md
@@ -1,44 +1,95 @@
-# Cloudflare Pages Readiness
+# Cloudflare Pages Production Hosting Runbook
 
-This repo is prepared for a Cloudflare Pages build without changing public DNS or removing GitHub Pages.
+This document reflects the current production hosting state for `elelier.com` after the Cloudflare Pages cutover.
 
-## Recommended Cloudflare Pages configuration
+## Current status
 
+- Cloudflare Pages is the primary production hosting platform.
+- GitHub Pages remains available only as a historical/manual rollback path and is not the active primary host.
+- Project name: `elelier`
 - Root directory: `my-app`
 - Build command: `npm run build`
 - Build output directory: `build`
 - Production branch: `main`
 - Node version: `20.19.0`
+- Technical URL: `https://elelier.pages.dev/`
+- Primary production domain: `https://elelier.com/`
+
+## Production domains
+
+- `elelier.com`: Active
+- `www.elelier.com`: Active
+- Pending non-blocking follow-up: evaluate a `301` redirect from `www` to apex after full stability is confirmed.
+
+## DNS summary
+
+- Apex uses Cloudflare Pages with CNAME flattening toward `elelier.pages.dev`.
+- `www` uses a CNAME toward `elelier.pages.dev`.
+- The `google-site-verification` TXT record was preserved during cutover.
+- Workers for forms/leads were preserved during cutover.
+- No MX records were configured at cutover time.
+- Do not paste full TXT values or other sensitive DNS data into this repository.
+- Nameservers were not changed during the cutover.
+
+## SPA routing
+
+The Cloudflare Pages `_redirects` contract uses narrowly scoped rules for dynamic and deep React routes. A global catch-all rule is intentionally not used, including:
+
+`/* /index.html 200`
+
+Expected deep-route coverage includes:
+
+- `/proyecto/:token`
+- `/cotizacion/:id`
+- `/mockup/:id`
+- `/admin/leads`
+- `/entradas/:slug`
+
+Accepted behavior for closed/private/deep routes is a safe redirect to home or a non-sensitive placeholder state, with no customer or admin data exposure.
 
 ## Environment variables
 
-Set these in Cloudflare Pages if you want parity with the current app behavior:
+Set these in Cloudflare Pages only if the deployed behavior requires parity with the current app:
 
-- `REACT_APP_GEMINI_API_KEY` (optional; only if you want to preserve chatbot/AI behavior)
+- `REACT_APP_GEMINI_API_KEY` (optional)
 - `REACT_APP_PASSCODE_ARQIDIA`
 - `REACT_APP_PASSCODE_HQCONTROL`
 - `REACT_APP_PASSCODE_ANDAMIOS`
 
 Do not paste real secret values into this repository.
 
-## Rollback posture
+## Post-cutover validation
 
-Keep GitHub Pages in place as the rollback path until the Cloudflare Pages production deployment is validated on the real domain. DNS cutover remains out of scope for this change.
+- Date: `2026-07-09`
+- Validated commit: `9b66a7c`
+- Result: `PASS ESTABLE`
+- Validated routes/artifacts:
+  - `/`
+  - `/contacto`
+  - `/blog`
+  - `/portafolio`
+  - `/robots.txt`
+  - `/sitemap.xml`
+  - `/manifest.json`
+  - private/utilitarian deep routes
+- No rollback was required.
 
-## Deep-route rewrite note
+## Rollback
 
-The first Cloudflare Pages smoke showed that wildcard prefix rules did not resolve the dynamic deep links. The `_redirects` contract therefore uses explicit rules and named placeholders for the React routes, while leaving prerendered routes and assets untouched.
+Use GitHub Pages rollback only if Cloudflare Pages fails persistently and production recovery cannot be achieved in place.
 
-## Smoke checklist for `*.pages.dev`
+Manual DNS rollback steps for apex:
 
-1. Load `/` and confirm the home sections render normally.
-2. Direct-open `/portafolio`, `/sobre-mi`, `/servicios`, `/contacto`, `/blog`, `/aionlabs`, `/privacy-policy`, and `/terms-of-service`.
-3. Direct-open `/proyecto/test-token`, `/cotizacion/test-id`, `/mockup/test-id`, `/admin/leads`, and `/entradas/2408_IA_Transforma_ecommerce` to confirm the SPA shell resolves instead of returning a static 404.
-4. Confirm static assets load correctly and no `_redirects` rule rewrites JS, CSS, images, `robots.txt`, or `sitemap.xml`.
-5. Confirm `CNAME`, `homepage`, `gh-pages`, and the existing GitHub Pages deploy flow remain unchanged in the repository.
+1. Restore these four GitHub Pages A records:
+   - `185.199.111.153`
+   - `185.199.110.153`
+   - `185.199.109.153`
+   - `185.199.108.153`
+2. Keep TXT records, Workers-backed forms/leads, and subdomains intact unless a separate inventory says otherwise.
+3. Do not change MX or TXT records without a validated DNS inventory.
 
-## Out of scope
+## Known non-blocking follow-ups
 
-- DNS cutover to Cloudflare Pages
-- Removing GitHub Pages
-- Dashboard-side configuration beyond the values listed above
+- Evaluate a `301` redirect from `www` to apex.
+- Evaluate a React `404` or placeholder component for closed private routes that currently redirect to home.
+- Maintain light monitoring for the first `24h` after cutover.

--- a/my-app/README.md
+++ b/my-app/README.md
@@ -96,7 +96,8 @@
 
 ### Herramientas de Desarrollo
 - **Git & GitHub**: Control de versiones
-- **GitHub Pages**: Alojamiento
+- **Cloudflare Pages**: Hosting productivo actual
+- **GitHub Pages**: Ruta legacy/manual de rollback
 - **NPM**: Gestión de paquetes
 - **React Scripts 5.0.1**: Herramientas de desarrollo
 
@@ -138,11 +139,11 @@
 
 ## Despliegue
 
-El portfolio está desplegado en GitHub Pages y accesible en [elelier.com](https://www.elelier.com).
+El portfolio tiene como hosting productivo actual Cloudflare Pages y está accesible en [elelier.com](https://elelier.com). GitHub Pages se conserva únicamente como ruta legacy/manual de rollback.
 
 ### Configuración de Producción
-- **Dominio Personalizado**: elelier.com configurado con CNAME
-- **HTTPS Habilitado**: SSL/TLS automático por GitHub Pages
+- **Dominio Personalizado**: `elelier.com` y `www.elelier.com` activos en Cloudflare Pages
+- **HTTPS Habilitado**: SSL/TLS automático por Cloudflare Pages
 - **Compresión de Activos**: Minificación automática de CSS/JS
 - **Caché Optimizado**: Headers de caché para recursos estáticos
 - **Analytics Configurado**: Google Tag Manager y Google Analytics 4
@@ -152,8 +153,8 @@ El portfolio está desplegado en GitHub Pages y accesible en [elelier.com](https
 ### Pipeline de Despliegue
 1. **Build Automático**: `npm run build` genera datos de cliente y construye
 2. **Optimización**: Minificación, tree-shaking y code-splitting
-3. **Deploy**: `npm run deploy` sube a GitHub Pages usando gh-pages
-4. **DNS**: Redirección automática de www.elelier.com a elelier.com
+3. **Deploy legacy/manual**: `npm run deploy` mantiene la ruta histórica de GitHub Pages con `gh-pages`
+4. **DNS**: Cloudflare Pages atiende `elelier.com` y `www.elelier.com`; una redirección `301` de `www` a apex sigue como evaluación no bloqueante
 
 ### Variables de Entorno Requeridas
 ```bash
@@ -203,7 +204,7 @@ npm test           # Ejecutar tests
 ### Producción
 ```bash
 npm run build      # Construir para producción (incluye generación de datos)
-npm run deploy     # Desplegar a GitHub Pages
+npm run deploy     # Ruta legacy/manual hacia GitHub Pages
 npm run predeploy  # Pre-construcción automática
 npm run pre-prod   # Testing local de build de producción
 ```


### PR DESCRIPTION
## Summary
- convert `my-app/CLOUDFLARE_PAGES.md` from pre-cutover readiness notes into a production hosting runbook for Cloudflare Pages
- update `README.md` and `my-app/README.md` to state that Cloudflare Pages is the active production host and GitHub Pages remains only as a legacy/manual rollback path
- keep deploy scripts, `gh-pages`, `CNAME`, runtime behavior, DNS, and dashboard settings unchanged

## Validation
- `npm test -- --runInBand --watchAll=false`
- `npm run build`
- `git diff --check`
- `git restore -- my-app/src/config/hashedPasscodes.js`
- `git status --short`

## Out of scope confirmation
- no DNS changes
- no Cloudflare dashboard changes
- no deploy
- no redirect activation
- no runtime changes
