### PR TITLE
Rediseño visual-first de la landing y proyectos

### DIFF
--- a/docs/superpowers/asset-audit-2026-07-10.md
+++ b/docs/superpowers/asset-audit-2026-07-10.md
@@ -1,0 +1,29 @@
+# Asset audit — visual-first landing
+
+## Existing coverage
+
+| Proyecto | Hero/thumb | Desktop/mobile | Galería dedicada | Acción recomendada |
+|---|---:|---:|---:|---|
+| Arqidia.mx | Sí | Sí, declarados en `sitesData` | Parcial: validar que existan las cuatro rutas | Capturar home, portafolio, mobile y contacto |
+| Elelier.com | Sí | No declarados | Parcial | Capturar hero, proyectos, métricas y mobile |
+| Monterrey Respira | Sí | No declarados | Parcial | Capturar dashboard, estado de aire y mobile |
+| Jasso Tours | Sí | No declarados | Parcial | Capturar landing, mapa, destino y mobile |
+| Wonderlabs Studio | Sí | No declarados | Parcial | Capturar creador, historia generada y resultado |
+| Space People | Sí | No declarados | Parcial | Capturar contador, estado vacío y responsive |
+| EL-QR Code Generator | Sí | No declarados | Parcial | Capturar formulario, QR generado y tracking |
+
+## Regla de incorporación
+
+La interfaz ya acepta una galería con cualquier número de imágenes y deduplica rutas repetidas. Mientras se capturan materiales adicionales, reutiliza `fullImage` y `thumbnail` sin mostrar espacios falsos.
+
+## Tomas sugeridas por proyecto
+
+1. Vista general desktop.
+2. Vista mobile real.
+3. Una interacción clave o flujo completo.
+4. Un detalle de interfaz que explique el valor.
+5. Estado final, métrica o resultado visible.
+
+## Insumos externos pendientes
+
+Las capturas de sitios publicados pueden agregarse cuando estén disponibles en el navegador o mediante archivos locales autorizados. No se bloquea la implementación por su ausencia; los proyectos muestran el material local existente y quedan listos para ampliar el arreglo `gallery` en `src/data/sites.js`.

--- a/docs/superpowers/plans/2026-07-10-visual-first-landing.md
+++ b/docs/superpowers/plans/2026-07-10-visual-first-landing.md
@@ -8,6 +8,8 @@
 
 **Tech Stack:** React 18, React Router 6, CSS, existing Framer Motion/react-swipeable utilities, Jest/React Testing Library, Create React App.
 
+**Current status (2026-07-10):** Tasks 1–4 implemented and production build verified. Task 5 remains in progress because the in-app browser cannot reach the local dev server from this session; asset gaps are documented in `docs/superpowers/asset-audit-2026-07-10.md`.
+
 ## Global Constraints
 
 - Text must stay concise and evidence-led.
@@ -17,7 +19,7 @@
 - Preserve Spanish and English content paths.
 - Reuse local assets before adding new dependencies.
 
-### Task 1: Establish the visual-first content model
+### Task 1: Establish the visual-first content model — COMPLETE
 
 **Files:**
 - Create: `my-app/src/data/projects.js`
@@ -61,7 +63,7 @@ git add my-app/src/data/projects.js my-app/src/data/sites.js my-app/src/data/pro
 git commit -m "feat: add visual-first project content model"
 ```
 
-### Task 2: Recompose the home around visual evidence
+### Task 2: Recompose the home around visual evidence — COMPLETE
 
 **Files:**
 - Modify: `my-app/src/App.js`
@@ -111,7 +113,7 @@ git add my-app/src/App.js my-app/src/components/HeroBanner.js my-app/src/compone
 git commit -m "feat: recompose landing around visual evidence"
 ```
 
-### Task 3: Make navigation and mobile behavior coherent
+### Task 3: Make navigation and mobile behavior coherent — COMPLETE
 
 **Files:**
 - Modify: `my-app/src/components/Navegacion.js`
@@ -147,7 +149,7 @@ git add my-app/src/components/Navegacion.js my-app/src/styles/components/Navegac
 git commit -m "feat: unify desktop and mobile navigation"
 ```
 
-### Task 4: Add public catalog and project detail pages
+### Task 4: Add public catalog and project detail pages — COMPLETE
 
 **Files:**
 - Create: `my-app/src/pages/ProjectsPage.jsx`

--- a/docs/superpowers/plans/2026-07-10-visual-first-landing.md
+++ b/docs/superpowers/plans/2026-07-10-visual-first-landing.md
@@ -160,7 +160,7 @@ git commit -m "feat: unify desktop and mobile navigation"
 
 **Interfaces:**
 - Route `/sites` renders the public catalog.
-- Route `/proyecto/:id` renders a project detail or a localized not-found state.
+- Route `/proyectos/:id` renders a project detail or a localized not-found state.
 
 - [ ] **Step 1: Write the failing route test**
 

--- a/docs/superpowers/specs/2026-07-10-visual-first-landing-design.md
+++ b/docs/superpowers/specs/2026-07-10-visual-first-landing-design.md
@@ -33,7 +33,7 @@ Los anchors deben coincidir con las secciones visibles. Las rutas dedicadas no d
 
 ## Proyectos y páginas dedicadas
 
-El modelo de proyecto tendrá `id`, `title`, `category`, `summary`, `featuredImage`, `gallery`, `metrics`, `role`, `stack`, `url` y `status`. La home muestra una selección; `/sites` será una vista pública de catálogo; `/proyecto/:id` mostrará detalle visual. Cada galería admite 5–8 imágenes con formatos y situaciones distintas: desktop, mobile, flujo, detalle, antes/después y contexto.
+El modelo de proyecto tendrá `id`, `title`, `category`, `summary`, `featuredImage`, `gallery`, `metrics`, `role`, `stack`, `url` y `status`. La home muestra una selección; `/sites` será una vista pública de catálogo; `/proyectos/:id` mostrará detalle visual. Cada galería admite 5–8 imágenes con formatos y situaciones distintas: desktop, mobile, flujo, detalle, antes/después y contexto.
 
 Si un proyecto todavía no tiene galería completa, la interfaz conserva una sola imagen y muestra el estado sin inventar resultados.
 

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -57,7 +57,7 @@ function App({ initialLanguage }) {
   const homeSections = [
     { key: 'hero', Component: HeroBanner },
     { key: 'resultados', Component: ResultsStrip },
-    { key: 'proyectos', Component: () => <FeaturedProjects projects={getProjects(initialLanguage)} /> },
+    { key: 'proyectos', Component: ({ style }) => <FeaturedProjects style={style} projects={getProjects(initialLanguage)} /> },
     { key: 'casos', Component: CasosEstudio },
     { key: 'soluciones', Component: Soluciones },
     { key: 'testimonios', Component: Testimonios },

--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -21,10 +21,15 @@ import SobreMi from './components/SobreMi';
 import Tarifario from './components/Tarifario';
 import FloatingButton from './components/FloatingButton';
 import ChatModal from './components/ChatModal';
+import ResultsStrip from './components/ResultsStrip';
+import FeaturedProjects from './components/FeaturedProjects';
+import { getProjects } from './data/projects';
 import ExternalRedirect from './components/ExternalRedirect';
 import ClientSpace from './components/ClientSpace';
 import SettingsMenu from './components/SettingsMenu';
 import AdminLeads from './pages/AdminLeads';
+import ProjectsPage from './pages/ProjectsPage';
+import ProjectDetailPage from './pages/ProjectDetailPage';
 import PrivacyPolicy from './pages/PrivacyPolicy';
 import TermsOfService from './pages/TermsOfService';
 import AionLabs from './components/AionLabs';
@@ -51,8 +56,10 @@ function App({ initialLanguage }) {
 
   const homeSections = [
     { key: 'hero', Component: HeroBanner },
-    { key: 'soluciones', Component: Soluciones },
+    { key: 'resultados', Component: ResultsStrip },
+    { key: 'proyectos', Component: () => <FeaturedProjects projects={getProjects(initialLanguage)} /> },
     { key: 'casos', Component: CasosEstudio },
+    { key: 'soluciones', Component: Soluciones },
     { key: 'testimonios', Component: Testimonios },
     { key: 'sobre-mi', Component: SobreMi },
     { key: 'portafolio', Component: Portafolio },
@@ -166,6 +173,22 @@ function App({ initialLanguage }) {
                     })}
                   />
                   <Route
+                    path="/sites"
+                    element={renderPublicAliasRoute(<ProjectsPage />, {
+                      route: '/sites',
+                      title: 'Proyectos | Elier Loya',
+                      description: 'Proyectos y productos digitales seleccionados de Elier Loya.'
+                    })}
+                  />
+                  <Route
+                    path="/proyectos/:id"
+                    element={renderPublicAliasRoute(<ProjectDetailPage />, {
+                      route: '/proyectos/:id',
+                      title: 'Proyecto | Elier Loya',
+                      description: 'Detalle visual de un proyecto digital de Elier Loya.'
+                    })}
+                  />
+                  <Route
                     path="/cotizacion/:id"
                     element={renderPrivateRoute(<ExternalRedirect />, {
                       title: 'Ruta privada | Elier Loya',
@@ -208,13 +231,6 @@ function App({ initialLanguage }) {
                       route: '/aionlabs',
                       title: getRouteSeoPolicy('/aionlabs')?.title,
                       description: getRouteSeoPolicy('/aionlabs')?.description,
-                    })}
-                  />
-                  <Route
-                    path="/sites"
-                    element={renderPrivateRoute(<InternalRoutePlaceholder />, {
-                      title: 'Vista utilitaria | Elier Loya',
-                      description: 'Vista interna con acceso controlado y sin indexacion publica.'
                     })}
                   />
                 </Routes>

--- a/my-app/src/components/FeaturedProjects.jsx
+++ b/my-app/src/components/FeaturedProjects.jsx
@@ -3,39 +3,41 @@ import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import '../styles/components/FeaturedProjects.css';
 
-function FeaturedProjects({ projects = [] }) {
+function FeaturedProjects({ projects = [], style }) {
   const { language } = useLanguage();
-  const visibleProjects = projects.filter((project) => project.featured).slice(0, 4);
+  const visibleProjects = projects.filter((project) => project.featured && project.featuredImage).slice(0, 4);
 
   return (
-    <section id="proyectos" className="featured-projects" aria-labelledby="featured-projects-title">
-      <div className="featured-projects__heading">
-        <div>
-          <span>{language === 'es' ? 'TRABAJO SELECCIONADO' : 'SELECTED WORK'}</span>
-          <h2 id="featured-projects-title">{language === 'es' ? 'Lo que ya está funcionando' : 'What is already working'}</h2>
-        </div>
-        <Link className="featured-projects__all" to="/sites">
-          {language === 'es' ? 'Ver todos ↗' : 'See all ↗'}
-        </Link>
-      </div>
-
-      <div className="featured-projects__grid">
-        {visibleProjects.map((project, index) => (
-          <Link className={`featured-project featured-project--${index + 1}`} to={`/proyectos/${project.id}`} key={project.id}>
-            <div className="featured-project__media">
-              <img src={project.featuredImage} alt={project.title} loading={index === 0 ? 'eager' : 'lazy'} />
-              <span className="featured-project__open" aria-hidden="true">↗</span>
-            </div>
-            <div className="featured-project__body">
-              <span>{project.category}</span>
-              <h3>{project.title}</h3>
-              <p>{project.summary}</p>
-              <div className="featured-project__metrics" aria-label={language === 'es' ? 'Aspectos destacados' : 'Highlights'}>
-                {project.metrics.slice(0, 3).map((metric) => <small key={metric}>{metric}</small>)}
-              </div>
-            </div>
+    <section id="proyectos" className="featured-projects" style={style} aria-labelledby="featured-projects-title">
+      <div className="featured-projects__inner">
+        <div className="featured-projects__heading">
+          <div>
+            <span>{language === 'es' ? 'TRABAJO SELECCIONADO' : 'SELECTED WORK'}</span>
+            <h2 id="featured-projects-title">{language === 'es' ? 'Lo que ya está funcionando' : 'What is already working'}</h2>
+          </div>
+          <Link className="featured-projects__all" to="/sites">
+            {language === 'es' ? 'Ver todos ↗' : 'See all ↗'}
           </Link>
-        ))}
+        </div>
+
+        <div className="featured-projects__grid">
+          {visibleProjects.map((project, index) => (
+            <Link className={`featured-project featured-project--${index + 1}`} to={`/proyectos/${project.id}`} key={project.id}>
+              <div className="featured-project__media">
+                {project.featuredImage ? <img src={project.featuredImage} alt={project.title} loading={index === 0 ? 'eager' : 'lazy'} /> : <div className="featured-project__placeholder"><span>{project.title}</span><small>{language === 'es' ? 'Imagen en preparación' : 'Image in progress'}</small></div>}
+                <span className="featured-project__open" aria-hidden="true">↗</span>
+              </div>
+              <div className="featured-project__body">
+                <span>{project.category}</span>
+                <h3>{project.title}</h3>
+                <p>{project.summary}</p>
+                <div className="featured-project__metrics" aria-label={language === 'es' ? 'Aspectos destacados' : 'Highlights'}>
+                  {project.metrics.slice(0, 3).map((metric) => <small key={metric}>{metric}</small>)}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/my-app/src/components/FeaturedProjects.jsx
+++ b/my-app/src/components/FeaturedProjects.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useLanguage } from '../contexts/LanguageContext';
+import '../styles/components/FeaturedProjects.css';
+
+function FeaturedProjects({ projects = [] }) {
+  const { language } = useLanguage();
+  const visibleProjects = projects.filter((project) => project.featured).slice(0, 4);
+
+  return (
+    <section id="proyectos" className="featured-projects" aria-labelledby="featured-projects-title">
+      <div className="featured-projects__heading">
+        <div>
+          <span>{language === 'es' ? 'TRABAJO SELECCIONADO' : 'SELECTED WORK'}</span>
+          <h2 id="featured-projects-title">{language === 'es' ? 'Lo que ya está funcionando' : 'What is already working'}</h2>
+        </div>
+        <Link className="featured-projects__all" to="/sites">
+          {language === 'es' ? 'Ver todos ↗' : 'See all ↗'}
+        </Link>
+      </div>
+
+      <div className="featured-projects__grid">
+        {visibleProjects.map((project, index) => (
+          <Link className={`featured-project featured-project--${index + 1}`} to={`/proyectos/${project.id}`} key={project.id}>
+            <div className="featured-project__media">
+              <img src={project.featuredImage} alt={project.title} loading={index === 0 ? 'eager' : 'lazy'} />
+              <span className="featured-project__open" aria-hidden="true">↗</span>
+            </div>
+            <div className="featured-project__body">
+              <span>{project.category}</span>
+              <h3>{project.title}</h3>
+              <p>{project.summary}</p>
+              <div className="featured-project__metrics" aria-label={language === 'es' ? 'Aspectos destacados' : 'Highlights'}>
+                {project.metrics.slice(0, 3).map((metric) => <small key={metric}>{metric}</small>)}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default FeaturedProjects;

--- a/my-app/src/components/FeaturedProjects.test.jsx
+++ b/my-app/src/components/FeaturedProjects.test.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import FeaturedProjects from './FeaturedProjects';
+
+jest.mock('../contexts/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'es' }),
+}));
+
+test('shows visual project cards and short summaries', () => {
+  render(
+    <MemoryRouter>
+      <FeaturedProjects projects={[{
+        id: 'demo',
+        title: 'Demo',
+        summary: 'Una frase',
+        featuredImage: '/demo.jpg',
+        category: 'Web',
+        metrics: ['+20%'],
+        featured: true,
+      }]} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByRole('heading', { name: 'Demo' })).toBeInTheDocument();
+  expect(screen.getByAltText('Demo')).toBeInTheDocument();
+  expect(screen.getByText('Una frase')).toBeInTheDocument();
+});
+

--- a/my-app/src/components/Navegacion.js
+++ b/my-app/src/components/Navegacion.js
@@ -6,7 +6,6 @@ import '../styles/components/Navegacion.css';
 
 function Navegacion() {
   const [menuOpen, setMenuOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
   const { language } = useLanguage();
 
   const toggleMenu = () => {
@@ -27,41 +26,41 @@ function Navegacion() {
   };
 
   useEffect(() => {
-    const handleClickOutside = (event) => {
-      // Aquí nos aseguramos que al hacer clic fuera del menú, se cierre
-      if (menuOpen && !event.target.closest('.nav-content') && !event.target.closest('.menu-toggle')) {
-        closeMenu();
-      }
-
-      // Aquí cerramos el menú de settings si está abierto y se hace clic afuera
-      if (settingsOpen && !event.target.closest('.settings-menu') && !event.target.closest('.settings-toggle')) {
-        setSettingsOpen(false);
-      }
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') closeMenu();
     };
 
-    document.addEventListener('click', handleClickOutside);
-
+    document.addEventListener('keydown', handleKeyDown);
+    document.body.classList.toggle('nav-menu-open', menuOpen);
     return () => {
-      document.removeEventListener('click', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.classList.remove('nav-menu-open');
     };
-  }, [menuOpen, settingsOpen]);
+  }, [menuOpen]);
 
   const navItems = {
     es: {
-      sobreMi: 'Sobre Mí',
+      proyectos: 'Proyectos',
+      resultados: 'Resultados',
       casosReales: 'Casos reales',
-      portafolio: 'Carrera',
-      soluciones: 'Soluciones',
+      comoTrabajo: 'Cómo trabajo',
       contactame: 'Hablemos de tu reto',
     },
     en: {
-      sobreMi: 'About Me',
+      proyectos: 'Projects',
+      resultados: 'Outcomes',
       casosReales: 'Case studies',
-      portafolio: 'Career',
-      soluciones: 'Solutions',
+      comoTrabajo: 'How I work',
       contactame: 'Let’s talk about your challenge',
     }
   };
+
+  const navLinks = [
+    ['proyectos', navItems[language].proyectos],
+    ['resultados', navItems[language].resultados],
+    ['casos-reales', navItems[language].casosReales],
+    ['como-trabajo', navItems[language].comoTrabajo],
+  ];
 
   return (
     <nav className="navegacion" role="navigation" aria-label="Navegación principal">
@@ -71,15 +70,15 @@ function Navegacion() {
             <div className="logo">Elier Loya Mata</div>
           </Link>
         </div>
-        <button className="menu-toggle" onClick={toggleMenu} aria-label="Toggle menu">
+        <button className="menu-toggle" onClick={toggleMenu} aria-expanded={menuOpen} aria-controls="primary-navigation" aria-label={menuOpen ? 'Close menu' : 'Open menu'}>
           {menuOpen ? '✖' : '☰'}
         </button>
-        <ul className={`nav-links ${menuOpen ? 'open' : ''}`}>
+        <div className={`nav-menu-backdrop ${menuOpen ? 'open' : ''}`} onClick={closeMenu} aria-hidden="true" />
+        <ul id="primary-navigation" className={`nav-links ${menuOpen ? 'open' : ''}`}>
           <li><Link to="/" onClick={() => handleScrollToElement('hero-banner')}><i className="fas fa-home"></i></Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('sobre-mi')}>{navItems[language].sobreMi}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('casos-reales')}>{navItems[language].casosReales}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('portafolio')}>{navItems[language].portafolio}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('soluciones')}>{navItems[language].soluciones}</Link></li>
+          {navLinks.map(([id, label]) => (
+            <li key={id}><Link to={`/#${id}`} onClick={() => handleScrollToElement(id)}>{label}</Link></li>
+          ))}
           <li>
             <Link
               to="/"

--- a/my-app/src/components/ResultsStrip.jsx
+++ b/my-app/src/components/ResultsStrip.jsx
@@ -17,27 +17,28 @@ const results = {
   ],
 };
 
-function ResultsStrip() {
+function ResultsStrip({ style }) {
   const { language } = useLanguage();
   const items = results[language] || results.es;
 
   return (
-    <section id="resultados" className="results-strip" aria-labelledby="results-title">
-      <div className="results-strip__intro">
-        <span>{language === 'es' ? 'EVIDENCIA' : 'EVIDENCE'}</span>
-        <h2 id="results-title">{language === 'es' ? 'Resultados que se pueden ver' : 'Outcomes you can see'}</h2>
-      </div>
-      <div className="results-strip__grid">
-        {items.map((item) => (
-          <div className="result-stat" key={item.label}>
-            <strong>{item.value}</strong>
-            <span>{item.label}</span>
-          </div>
-        ))}
+    <section id="resultados" className="results-strip" style={style} aria-labelledby="results-title">
+      <div className="results-strip__inner">
+        <div className="results-strip__intro">
+          <span>{language === 'es' ? 'EVIDENCIA' : 'EVIDENCE'}</span>
+          <h2 id="results-title">{language === 'es' ? 'Resultados que se pueden ver' : 'Outcomes you can see'}</h2>
+        </div>
+        <div className="results-strip__grid">
+          {items.map((item) => (
+            <div className="result-stat" key={item.label}>
+              <strong>{item.value}</strong>
+              <span>{item.label}</span>
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );
 }
 
 export default ResultsStrip;
-

--- a/my-app/src/components/ResultsStrip.jsx
+++ b/my-app/src/components/ResultsStrip.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useLanguage } from '../contexts/LanguageContext';
+import '../styles/components/ResultsStrip.css';
+
+const results = {
+  es: [
+    { value: '99.8%', label: 'precisión de inventario' },
+    { value: '+144%', label: 'crecimiento en marketplace' },
+    { value: '−50%', label: 'reclamos y cancelaciones' },
+    { value: '+10', label: 'años entre operación y producto' },
+  ],
+  en: [
+    { value: '99.8%', label: 'inventory accuracy' },
+    { value: '+144%', label: 'marketplace growth' },
+    { value: '−50%', label: 'claims and cancellations' },
+    { value: '+10', label: 'years across operations and product' },
+  ],
+};
+
+function ResultsStrip() {
+  const { language } = useLanguage();
+  const items = results[language] || results.es;
+
+  return (
+    <section id="resultados" className="results-strip" aria-labelledby="results-title">
+      <div className="results-strip__intro">
+        <span>{language === 'es' ? 'EVIDENCIA' : 'EVIDENCE'}</span>
+        <h2 id="results-title">{language === 'es' ? 'Resultados que se pueden ver' : 'Outcomes you can see'}</h2>
+      </div>
+      <div className="results-strip__grid">
+        {items.map((item) => (
+          <div className="result-stat" key={item.label}>
+            <strong>{item.value}</strong>
+            <span>{item.label}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default ResultsStrip;
+

--- a/my-app/src/data/projects.js
+++ b/my-app/src/data/projects.js
@@ -1,4 +1,11 @@
 import { sitesData } from './sites';
+import arqidiaPreview from '../assets/images/casos-arqidia-preview.jpg';
+import elelierPreview from '../assets/images/eleliercom.png';
+
+const visualFallbacks = {
+  'diana-mtz': [arqidiaPreview, '/images/sites/cover-desktop.jpg', '/images/sites/cover-mobile.jpg'],
+  elelier: [elelierPreview, '/images/sites/elelier-full.jpg', '/images/sites/elelier-thumb.jpg'],
+};
 
 const projectContent = {
   es: {
@@ -64,13 +71,13 @@ const getLocalizedContent = (language, id) => (projectContent[language] || proje
 
 const toProject = (site, language) => {
   const copy = getLocalizedContent(language, site.id);
+  const fallbackGallery = visualFallbacks[site.id] || [];
   const gallery = [
     site.images?.desktop?.carousel,
     site.images?.desktop?.grid,
     site.images?.mobile?.carousel,
     site.images?.mobile?.grid,
-    site.fullImage,
-    site.thumbnail,
+    ...fallbackGallery,
   ].filter(Boolean).filter((image, index, images) => images.indexOf(image) === index);
 
   return {
@@ -80,7 +87,7 @@ const toProject = (site, language) => {
     summary: copy.summary,
     role: copy.role,
     metrics: copy.metrics,
-    featuredImage: site.fullImage || site.thumbnail,
+    featuredImage: gallery[0] || null,
     gallery,
   };
 };
@@ -93,4 +100,3 @@ export const projectsData = {
 export const getProjects = (language = 'es') => projectsData[language] || projectsData.es;
 
 export const getProjectById = (id, language = 'es') => getProjects(language).find((project) => project.id === id) || null;
-

--- a/my-app/src/data/projects.js
+++ b/my-app/src/data/projects.js
@@ -1,0 +1,96 @@
+import { sitesData } from './sites';
+
+const projectContent = {
+  es: {
+    'diana-mtz': {
+      category: 'Arquitectura · presencia digital',
+      summary: 'Una presencia digital clara para convertir visitas en conversaciones.',
+      role: 'Producto digital, UX y construcción web',
+      metrics: ['Portfolio visual', 'SEO técnico', 'Captación'],
+    },
+    elelier: {
+      category: 'Portfolio · transformación digital',
+      summary: 'Un sistema vivo para explicar experiencia, resultados y formas de trabajo.',
+      role: 'Estrategia, producto y ejecución',
+      metrics: ['React', 'Contenido bilingüe', 'Experiencia responsive'],
+    },
+    'monterrey-respira': {
+      category: 'Datos · utilidad pública',
+      summary: 'Información ambiental en tiempo real, convertida en una experiencia fácil de consultar.',
+      role: 'Producto web y datos',
+      metrics: ['Tiempo real', 'Supabase', 'API pública'],
+    },
+    'jasso-tours': {
+      category: 'Turismo · conversión',
+      summary: 'Una landing que hace tangible el destino y facilita el siguiente paso.',
+      role: 'Experiencia digital y construcción web',
+      metrics: ['Responsive', 'Mapas', 'AWS'],
+    },
+  },
+  en: {
+    'diana-mtz': {
+      category: 'Architecture · digital presence',
+      summary: 'A clear digital presence designed to turn visits into conversations.',
+      role: 'Digital product, UX and web delivery',
+      metrics: ['Visual portfolio', 'Technical SEO', 'Lead generation'],
+    },
+    elelier: {
+      category: 'Portfolio · digital transformation',
+      summary: 'A living system to explain experience, outcomes and ways of working.',
+      role: 'Strategy, product and delivery',
+      metrics: ['React', 'Bilingual content', 'Responsive experience'],
+    },
+    'monterrey-respira': {
+      category: 'Data · public utility',
+      summary: 'Real-time environmental information turned into an easy-to-use experience.',
+      role: 'Web product and data',
+      metrics: ['Real time', 'Supabase', 'Public API'],
+    },
+    'jasso-tours': {
+      category: 'Travel · conversion',
+      summary: 'A landing page that makes the destination tangible and clarifies the next step.',
+      role: 'Digital experience and web delivery',
+      metrics: ['Responsive', 'Maps', 'AWS'],
+    },
+  },
+};
+
+const getLocalizedContent = (language, id) => (projectContent[language] || projectContent.es)[id] || {
+  category: 'Proyecto digital',
+  summary: 'Una solución digital construida para resolver un reto concreto.',
+  role: 'Producto y ejecución',
+  metrics: [],
+};
+
+const toProject = (site, language) => {
+  const copy = getLocalizedContent(language, site.id);
+  const gallery = [
+    site.images?.desktop?.carousel,
+    site.images?.desktop?.grid,
+    site.images?.mobile?.carousel,
+    site.images?.mobile?.grid,
+    site.fullImage,
+    site.thumbnail,
+  ].filter(Boolean).filter((image, index, images) => images.indexOf(image) === index);
+
+  return {
+    ...site,
+    title: site.name,
+    category: copy.category,
+    summary: copy.summary,
+    role: copy.role,
+    metrics: copy.metrics,
+    featuredImage: site.fullImage || site.thumbnail,
+    gallery,
+  };
+};
+
+export const projectsData = {
+  es: sitesData.es.map((site) => toProject(site, 'es')),
+  en: sitesData.en.map((site) => toProject(site, 'en')),
+};
+
+export const getProjects = (language = 'es') => projectsData[language] || projectsData.es;
+
+export const getProjectById = (id, language = 'es') => getProjects(language).find((project) => project.id === id) || null;
+

--- a/my-app/src/data/projects.test.js
+++ b/my-app/src/data/projects.test.js
@@ -1,0 +1,14 @@
+import { getProjectById, getProjects } from './projects';
+
+test('returns localized projects with gallery-safe fields', () => {
+  const projects = getProjects('es');
+
+  expect(projects.length).toBeGreaterThan(0);
+  expect(projects[0]).toEqual(expect.objectContaining({
+    id: expect.any(String),
+    gallery: expect.any(Array),
+    featuredImage: expect.any(String),
+  }));
+  expect(getProjectById(projects[0].id, 'es')).toBe(projects[0]);
+});
+

--- a/my-app/src/pages/ProjectDetailPage.jsx
+++ b/my-app/src/pages/ProjectDetailPage.jsx
@@ -15,7 +15,7 @@ function ProjectDetailPage() {
   }
 
   const related = getProjects(language).filter((candidate) => candidate.id !== project.id).slice(0, 2);
-  const gallery = project.gallery.length ? project.gallery : [project.featuredImage];
+  const gallery = project.gallery.length ? project.gallery : [];
   const copy = language === 'es'
     ? { back: 'Todos los proyectos', overview: 'En una frase', role: 'Mi papel', stack: 'Construido con', visit: 'Visitar proyecto ↗', related: 'También puedes ver' }
     : { back: 'All projects', overview: 'In one sentence', role: 'My role', stack: 'Built with', visit: 'Visit project ↗', related: 'You may also like' };
@@ -30,14 +30,14 @@ function ProjectDetailPage() {
       </header>
 
       <section className="project-gallery" aria-label={language === 'es' ? 'Galería del proyecto' : 'Project gallery'}>
-        <div className="project-gallery__main"><img src={gallery[activeImage]} alt={`${project.title} ${activeImage + 1}`} /></div>
-        <div className="project-gallery__thumbs">
+        <div className="project-gallery__main">{gallery.length ? <img src={gallery[activeImage]} alt={`${project.title} ${activeImage + 1}`} /> : <div className="project-gallery__placeholder"><strong>{project.title}</strong><span>{language === 'es' ? 'Galería visual en preparación' : 'Visual gallery in progress'}</span></div>}</div>
+        {gallery.length > 0 && <div className="project-gallery__thumbs">
           {gallery.map((image, index) => (
             <button type="button" className={index === activeImage ? 'active' : ''} onClick={() => setActiveImage(index)} key={image} aria-label={`${project.title} ${index + 1}`}>
               <img src={image} alt="" />
             </button>
           ))}
-        </div>
+        </div>}
       </section>
 
       <section className="project-detail__facts">
@@ -51,11 +51,10 @@ function ProjectDetailPage() {
 
       <section className="project-detail__related" aria-labelledby="related-projects-title">
         <h2 id="related-projects-title">{copy.related}</h2>
-        <div>{related.map((candidate) => <Link to={`/proyectos/${candidate.id}`} key={candidate.id}><img src={candidate.featuredImage} alt={candidate.title} /><span>{candidate.title} ↗</span></Link>)}</div>
+        <div>{related.map((candidate) => <Link to={`/proyectos/${candidate.id}`} key={candidate.id}>{candidate.featuredImage ? <img src={candidate.featuredImage} alt={candidate.title} /> : <div className="project-detail__related-placeholder">{candidate.title}</div>}<span>{candidate.title} ↗</span></Link>)}</div>
       </section>
     </main>
   );
 }
 
 export default ProjectDetailPage;
-

--- a/my-app/src/pages/ProjectDetailPage.jsx
+++ b/my-app/src/pages/ProjectDetailPage.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { useLanguage } from '../contexts/LanguageContext';
+import { getProjectById, getProjects } from '../data/projects';
+import '../styles/pages/ProjectDetailPage.css';
+
+function ProjectDetailPage() {
+  const { id } = useParams();
+  const { language } = useLanguage();
+  const project = getProjectById(id, language);
+  const [activeImage, setActiveImage] = useState(0);
+
+  if (!project) {
+    return <main className="project-detail project-detail--empty"><h1>{language === 'es' ? 'Proyecto no encontrado' : 'Project not found'}</h1><Link to="/sites">← {language === 'es' ? 'Ver proyectos' : 'See projects'}</Link></main>;
+  }
+
+  const related = getProjects(language).filter((candidate) => candidate.id !== project.id).slice(0, 2);
+  const gallery = project.gallery.length ? project.gallery : [project.featuredImage];
+  const copy = language === 'es'
+    ? { back: 'Todos los proyectos', overview: 'En una frase', role: 'Mi papel', stack: 'Construido con', visit: 'Visitar proyecto ↗', related: 'También puedes ver' }
+    : { back: 'All projects', overview: 'In one sentence', role: 'My role', stack: 'Built with', visit: 'Visit project ↗', related: 'You may also like' };
+
+  return (
+    <main className="project-detail">
+      <Link to="/sites" className="project-detail__back">← {copy.back}</Link>
+      <header className="project-detail__hero">
+        <span>{project.category}</span>
+        <h1>{project.title}</h1>
+        <p>{project.summary}</p>
+      </header>
+
+      <section className="project-gallery" aria-label={language === 'es' ? 'Galería del proyecto' : 'Project gallery'}>
+        <div className="project-gallery__main"><img src={gallery[activeImage]} alt={`${project.title} ${activeImage + 1}`} /></div>
+        <div className="project-gallery__thumbs">
+          {gallery.map((image, index) => (
+            <button type="button" className={index === activeImage ? 'active' : ''} onClick={() => setActiveImage(index)} key={image} aria-label={`${project.title} ${index + 1}`}>
+              <img src={image} alt="" />
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="project-detail__facts">
+        <div><span>{copy.overview}</span><p>{project.longDescription || project.summary}</p></div>
+        <div><span>{copy.role}</span><p>{project.role}</p></div>
+        <div><span>{copy.stack}</span><p>{project.tech?.join(' · ')}</p></div>
+        <div>{project.url && <a href={project.url} target="_blank" rel="noopener noreferrer">{copy.visit}</a>}</div>
+      </section>
+
+      {project.metrics.length > 0 && <ul className="project-detail__metrics">{project.metrics.map((metric) => <li key={metric}>{metric}</li>)}</ul>}
+
+      <section className="project-detail__related" aria-labelledby="related-projects-title">
+        <h2 id="related-projects-title">{copy.related}</h2>
+        <div>{related.map((candidate) => <Link to={`/proyectos/${candidate.id}`} key={candidate.id}><img src={candidate.featuredImage} alt={candidate.title} /><span>{candidate.title} ↗</span></Link>)}</div>
+      </section>
+    </main>
+  );
+}
+
+export default ProjectDetailPage;
+

--- a/my-app/src/pages/ProjectsPage.jsx
+++ b/my-app/src/pages/ProjectsPage.jsx
@@ -22,7 +22,7 @@ function ProjectsPage() {
       <div className="projects-page__grid">
         {projects.map((project) => (
           <Link className="project-index-card" to={`/proyectos/${project.id}`} key={project.id}>
-            <div className="project-index-card__media"><img src={project.featuredImage} alt={project.title} loading="lazy" /></div>
+            <div className="project-index-card__media">{project.featuredImage ? <img src={project.featuredImage} alt={project.title} loading="lazy" /> : <div className="project-index-card__placeholder"><span>{project.title}</span><small>{language === 'es' ? 'Imagen en preparación' : 'Image in progress'}</small></div>}</div>
             <div className="project-index-card__body">
               <span>{project.category}</span>
               <h2>{project.title}</h2>
@@ -37,4 +37,3 @@ function ProjectsPage() {
 }
 
 export default ProjectsPage;
-

--- a/my-app/src/pages/ProjectsPage.jsx
+++ b/my-app/src/pages/ProjectsPage.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { useLanguage } from '../contexts/LanguageContext';
+import { getProjects } from '../data/projects';
+import '../styles/pages/ProjectsPage.css';
+
+function ProjectsPage() {
+  const { language } = useLanguage();
+  const projects = getProjects(language);
+  const copy = language === 'es'
+    ? { eyebrow: 'ARCHIVO DE TRABAJO', title: 'Proyectos que puedes explorar', intro: 'Una selección de productos, sitios y sistemas construidos para resolver retos concretos.', back: 'Volver a la home' }
+    : { eyebrow: 'WORK ARCHIVE', title: 'Projects you can explore', intro: 'A selection of products, sites and systems built to solve concrete challenges.', back: 'Back home' };
+
+  return (
+    <main className="projects-page">
+      <header className="projects-page__header">
+        <Link to="/" className="projects-page__back">← {copy.back}</Link>
+        <span>{copy.eyebrow}</span>
+        <h1>{copy.title}</h1>
+        <p>{copy.intro}</p>
+      </header>
+      <div className="projects-page__grid">
+        {projects.map((project) => (
+          <Link className="project-index-card" to={`/proyectos/${project.id}`} key={project.id}>
+            <div className="project-index-card__media"><img src={project.featuredImage} alt={project.title} loading="lazy" /></div>
+            <div className="project-index-card__body">
+              <span>{project.category}</span>
+              <h2>{project.title}</h2>
+              <p>{project.summary}</p>
+              <b>↗</b>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </main>
+  );
+}
+
+export default ProjectsPage;
+

--- a/my-app/src/styles/components/FeaturedProjects.css
+++ b/my-app/src/styles/components/FeaturedProjects.css
@@ -1,0 +1,31 @@
+.featured-projects { max-width: 1240px; margin: 0 auto; padding: 76px 5vw 92px; color: var(--color-text); }
+.featured-projects__heading { display: flex; justify-content: space-between; align-items: end; gap: 24px; margin-bottom: 30px; }
+.featured-projects h2 { margin: 12px 0 0; font-size: clamp(2rem, 4vw, 4rem); line-height: .95; letter-spacing: -.04em; }
+.featured-projects__all { color: var(--color-text); text-decoration: none; border-bottom: 1px solid currentColor; padding-bottom: 5px; white-space: nowrap; }
+.featured-projects__grid { display: grid; grid-template-columns: 1.25fr .75fr; gap: 18px; }
+.featured-project { display: block; color: inherit; text-decoration: none; background: rgba(255,255,255,.035); border: 1px solid rgba(127,127,127,.2); transition: transform .35s ease, border-color .35s ease, background .35s ease; }
+.featured-project:hover, .featured-project:focus-visible { transform: translateY(-5px); border-color: var(--color-accent); background: rgba(255,255,255,.08); }
+.featured-project--1 { grid-row: span 2; }
+.featured-project__media { position: relative; aspect-ratio: 16 / 10; overflow: hidden; background: #151a24; }
+.featured-project--1 .featured-project__media { aspect-ratio: 16 / 12; }
+.featured-project__media img { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform .7s cubic-bezier(.2,.7,.2,1); }
+.featured-project:hover .featured-project__media img, .featured-project:focus-visible .featured-project__media img { transform: scale(1.04); }
+.featured-project__open { position: absolute; top: 14px; right: 14px; display: grid; place-items: center; width: 34px; height: 34px; border-radius: 50%; background: rgba(10, 14, 22, .75); color: #fff; }
+.featured-project__body { padding: 18px 20px 22px; }
+.featured-project__body > span { color: var(--color-accent); font-size: .68rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.featured-project h3 { margin: 8px 0 7px; font-size: clamp(1.25rem, 2vw, 2rem); }
+.featured-project p { margin: 0; max-width: 42rem; color: var(--color-text-muted, #99a2b2); line-height: 1.45; }
+.featured-project__metrics { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 16px; }
+.featured-project__metrics small { border: 1px solid rgba(127,127,127,.3); border-radius: 999px; padding: 5px 9px; color: var(--color-text-muted, #99a2b2); }
+
+@media (max-width: 800px) {
+  .featured-projects { padding: 58px 22px 70px; }
+  .featured-projects__heading { align-items: start; flex-direction: column; }
+  .featured-projects__grid { grid-template-columns: 1fr; }
+  .featured-project--1 { grid-row: auto; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .featured-project, .featured-project__media img { transition: none; }
+}
+

--- a/my-app/src/styles/components/FeaturedProjects.css
+++ b/my-app/src/styles/components/FeaturedProjects.css
@@ -1,14 +1,18 @@
-.featured-projects { max-width: 1240px; margin: 0 auto; padding: 76px 5vw 92px; color: var(--color-text); }
+.featured-projects { width: 100%; margin: 0 auto; padding: 86px 20px 92px; color: var(--color-text); background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg)), var(--section-bg-end, var(--color-bg-3))); scroll-margin-top: 78px; }
+.featured-projects__inner { width: min(1120px, 100%); margin: 0 auto; }
 .featured-projects__heading { display: flex; justify-content: space-between; align-items: end; gap: 24px; margin-bottom: 30px; }
 .featured-projects h2 { margin: 12px 0 0; font-size: clamp(2rem, 4vw, 4rem); line-height: .95; letter-spacing: -.04em; }
 .featured-projects__all { color: var(--color-text); text-decoration: none; border-bottom: 1px solid currentColor; padding-bottom: 5px; white-space: nowrap; }
 .featured-projects__grid { display: grid; grid-template-columns: 1.25fr .75fr; gap: 18px; }
-.featured-project { display: block; color: inherit; text-decoration: none; background: rgba(255,255,255,.035); border: 1px solid rgba(127,127,127,.2); transition: transform .35s ease, border-color .35s ease, background .35s ease; }
-.featured-project:hover, .featured-project:focus-visible { transform: translateY(-5px); border-color: var(--color-accent); background: rgba(255,255,255,.08); }
+.featured-project { display: block; color: inherit; text-decoration: none; background: var(--color-bg-solid); border: 1px solid var(--ui-card-border); border-radius: var(--ui-radius-card); box-shadow: var(--ui-card-shadow); overflow: hidden; transition: transform var(--ui-transition), border-color var(--ui-transition), box-shadow var(--ui-transition); }
+.featured-project:hover, .featured-project:focus-visible { transform: translateY(-4px); border-color: var(--color-accent); box-shadow: var(--ui-card-shadow-hover); }
 .featured-project--1 { grid-row: span 2; }
-.featured-project__media { position: relative; aspect-ratio: 16 / 10; overflow: hidden; background: #151a24; }
+.featured-project__media { position: relative; aspect-ratio: 16 / 10; overflow: hidden; background: var(--color-bg); }
 .featured-project--1 .featured-project__media { aspect-ratio: 16 / 12; }
 .featured-project__media img { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform .7s cubic-bezier(.2,.7,.2,1); }
+.featured-project__placeholder, .project-index-card__placeholder, .project-gallery__placeholder { width: 100%; height: 100%; display: grid; place-content: center; gap: 8px; padding: 24px; color: var(--color-text); background: linear-gradient(135deg, var(--color-bg-2), var(--color-bg-3)); text-align: center; }
+.featured-project__placeholder span, .project-index-card__placeholder span { font-size: 1.3rem; font-weight: 700; }
+.featured-project__placeholder small, .project-index-card__placeholder small { color: var(--color-secondary); }
 .featured-project:hover .featured-project__media img, .featured-project:focus-visible .featured-project__media img { transform: scale(1.04); }
 .featured-project__open { position: absolute; top: 14px; right: 14px; display: grid; place-items: center; width: 34px; height: 34px; border-radius: 50%; background: rgba(10, 14, 22, .75); color: #fff; }
 .featured-project__body { padding: 18px 20px 22px; }
@@ -19,7 +23,7 @@
 .featured-project__metrics small { border: 1px solid rgba(127,127,127,.3); border-radius: 999px; padding: 5px 9px; color: var(--color-text-muted, #99a2b2); }
 
 @media (max-width: 800px) {
-  .featured-projects { padding: 58px 22px 70px; }
+  .featured-projects { padding: 54px 14px 70px; }
   .featured-projects__heading { align-items: start; flex-direction: column; }
   .featured-projects__grid { grid-template-columns: 1fr; }
   .featured-project--1 { grid-row: auto; }
@@ -28,4 +32,3 @@
 @media (prefers-reduced-motion: reduce) {
   .featured-project, .featured-project__media img { transition: none; }
 }
-

--- a/my-app/src/styles/components/Navegacion.css
+++ b/my-app/src/styles/components/Navegacion.css
@@ -310,6 +310,37 @@
   
 }
 
+/* Visual-first navigation overrides */
+.navegacion {
+  backdrop-filter: blur(16px);
+  background-color: color-mix(in srgb, var(--color-bg) 82%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-text) 12%, transparent);
+  opacity: 1;
+}
+
+.nav-links { gap: 12px; }
+.nav-links li { margin-left: 0; }
+.nav-links a { font-size: .86rem; }
+.menu-toggle { right: 18px; }
+.nav-menu-backdrop { display: none; }
+
+@media (max-width: 830px) {
+  .nav-content { padding: 0 22px; }
+  .logo-container { left: 22px; transform: none; top: 0; }
+  .logo { font-size: 18px; }
+  .nav-links { z-index: 1000; left: auto; right: -100%; width: min(86vw, 360px); padding: 92px 28px 32px; align-items: stretch; justify-content: flex-start; gap: 0; transition: right .3s ease; box-shadow: -20px 0 50px rgba(0,0,0,.2); }
+  .nav-links.open { left: auto; right: 0; padding-top: 92px; }
+  .nav-links li { margin: 0; }
+  .nav-links a { padding: 16px 0; font-size: 1.2rem; border-bottom: 1px solid rgba(127,127,127,.2); }
+  .nav-menu-backdrop { display: block; position: fixed; inset: 0; z-index: 999; background: rgba(5, 8, 15, .55); opacity: 0; pointer-events: none; transition: opacity .3s ease; }
+  .nav-menu-backdrop.open { opacity: 1; pointer-events: auto; }
+  .nav-links .contact-button { display: flex; margin: 20px 0 0; font-size: 1rem; justify-content: center; border: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-links, .nav-menu-backdrop { transition: none; }
+}
+
 
 /* CSS */
 .language-toggle {

--- a/my-app/src/styles/components/ResultsStrip.css
+++ b/my-app/src/styles/components/ResultsStrip.css
@@ -1,12 +1,12 @@
 .results-strip {
-  display: grid;
-  grid-template-columns: minmax(220px, .8fr) 1.8fr;
-  gap: 48px;
-  max-width: 1240px;
+  width: 100%;
   margin: 0 auto;
   padding: 72px 5vw;
   color: var(--color-text);
+  background: linear-gradient(to bottom, var(--section-bg-start, var(--color-bg)), var(--section-bg-end, var(--color-bg-3)));
+  scroll-margin-top: 78px;
 }
+.results-strip__inner { display: grid; grid-template-columns: minmax(220px, .8fr) 1.8fr; gap: 48px; width: min(1120px, 100%); margin: 0 auto; }
 
 .results-strip__intro span,
 .featured-projects__heading > div > span {
@@ -16,14 +16,14 @@
   letter-spacing: .18em;
 }
 
-.results-strip h2 { margin: 12px 0 0; font-size: clamp(1.6rem, 3vw, 2.6rem); line-height: 1; }
+.results-strip h2 { margin: 12px 0 0; color: var(--hero-title-color-2); font-size: clamp(1.6rem, 3vw, 2.6rem); line-height: 1; }
 .results-strip__grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
-.result-stat { border-top: 1px solid rgba(127, 127, 127, .3); padding-top: 16px; }
+.result-stat { border-top: 1px solid var(--ui-card-border); padding-top: 16px; }
 .result-stat strong { display: block; font-size: clamp(1.8rem, 4vw, 3.2rem); line-height: .95; }
 .result-stat span { display: block; margin-top: 10px; color: var(--color-text-muted, #8e97a6); font-size: .8rem; line-height: 1.35; }
 
 @media (max-width: 800px) {
-  .results-strip { grid-template-columns: 1fr; gap: 28px; padding: 56px 22px; }
+  .results-strip { padding: 54px 14px; }
+  .results-strip__inner { grid-template-columns: 1fr; gap: 28px; }
   .results-strip__grid { grid-template-columns: repeat(2, 1fr); }
 }
-

--- a/my-app/src/styles/components/ResultsStrip.css
+++ b/my-app/src/styles/components/ResultsStrip.css
@@ -1,0 +1,29 @@
+.results-strip {
+  display: grid;
+  grid-template-columns: minmax(220px, .8fr) 1.8fr;
+  gap: 48px;
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 72px 5vw;
+  color: var(--color-text);
+}
+
+.results-strip__intro span,
+.featured-projects__heading > div > span {
+  color: var(--color-accent);
+  font-size: .7rem;
+  font-weight: 800;
+  letter-spacing: .18em;
+}
+
+.results-strip h2 { margin: 12px 0 0; font-size: clamp(1.6rem, 3vw, 2.6rem); line-height: 1; }
+.results-strip__grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 18px; }
+.result-stat { border-top: 1px solid rgba(127, 127, 127, .3); padding-top: 16px; }
+.result-stat strong { display: block; font-size: clamp(1.8rem, 4vw, 3.2rem); line-height: .95; }
+.result-stat span { display: block; margin-top: 10px; color: var(--color-text-muted, #8e97a6); font-size: .8rem; line-height: 1.35; }
+
+@media (max-width: 800px) {
+  .results-strip { grid-template-columns: 1fr; gap: 28px; padding: 56px 22px; }
+  .results-strip__grid { grid-template-columns: repeat(2, 1fr); }
+}
+

--- a/my-app/src/styles/pages/ProjectDetailPage.css
+++ b/my-app/src/styles/pages/ProjectDetailPage.css
@@ -1,0 +1,29 @@
+.project-detail { max-width: 1240px; margin: 0 auto; padding: 140px 5vw 90px; color: var(--color-text); }
+.project-detail__hero { max-width: 860px; margin-bottom: 42px; }
+.project-detail__hero > span { color: var(--color-accent); font-size: .72rem; font-weight: 800; letter-spacing: .16em; text-transform: uppercase; }
+.project-detail h1 { margin: 14px 0; font-size: clamp(3rem, 9vw, 8rem); line-height: .84; letter-spacing: -.07em; }
+.project-detail__hero p { max-width: 650px; color: var(--color-text-muted, #9aa3b2); font-size: 1.15rem; line-height: 1.45; }
+.project-gallery__main { aspect-ratio: 16/9; overflow: hidden; background: #131924; }
+.project-gallery__main img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.project-gallery__thumbs { display: flex; gap: 10px; overflow-x: auto; padding-top: 12px; }
+.project-gallery__thumbs button { flex: 0 0 110px; padding: 0; border: 2px solid transparent; background: none; cursor: pointer; opacity: .55; }
+.project-gallery__thumbs button.active, .project-gallery__thumbs button:focus-visible { border-color: var(--color-accent); opacity: 1; }
+.project-gallery__thumbs img { display: block; width: 100%; aspect-ratio: 4/3; object-fit: cover; }
+.project-detail__facts { display: grid; grid-template-columns: 1.5fr 1fr 1.5fr auto; gap: 24px; margin: 52px 0 34px; padding: 24px 0; border-block: 1px solid rgba(127,127,127,.25); }
+.project-detail__facts span { color: var(--color-accent); font-size: .7rem; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+.project-detail__facts p { margin: 10px 0 0; color: var(--color-text-muted, #9aa3b2); line-height: 1.45; }
+.project-detail__facts a { color: var(--color-text); font-weight: 700; }
+.project-detail__metrics { display: flex; flex-wrap: wrap; gap: 10px; list-style: none; padding: 0; }
+.project-detail__metrics li { padding: 8px 12px; border: 1px solid rgba(127,127,127,.3); border-radius: 999px; }
+.project-detail__related { margin-top: 100px; }
+.project-detail__related h2 { font-size: 1.7rem; }
+.project-detail__related > div { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+.project-detail__related a { position: relative; color: #fff; text-decoration: none; overflow: hidden; }
+.project-detail__related img { display: block; width: 100%; aspect-ratio: 16/8; object-fit: cover; filter: brightness(.7); transition: transform .5s ease, filter .5s ease; }
+.project-detail__related a:hover img { transform: scale(1.04); filter: brightness(.9); }
+.project-detail__related span { position: absolute; left: 18px; bottom: 16px; font-size: 1.25rem; font-weight: 700; }
+.project-detail--empty { min-height: 70vh; display: grid; place-content: center; text-align: center; }
+@media (max-width: 800px) { .project-detail { padding: 110px 22px 70px; } .project-detail__facts { grid-template-columns: repeat(2, 1fr); } .project-detail__related > div { grid-template-columns: 1fr; } }
+@media (max-width: 480px) { .project-detail__facts { grid-template-columns: 1fr; } }
+@media (prefers-reduced-motion: reduce) { .project-detail__related img { transition: none; } }
+

--- a/my-app/src/styles/pages/ProjectDetailPage.css
+++ b/my-app/src/styles/pages/ProjectDetailPage.css
@@ -1,10 +1,11 @@
-.project-detail { max-width: 1240px; margin: 0 auto; padding: 140px 5vw 90px; color: var(--color-text); }
+.project-detail { max-width: 1240px; margin: 0 auto; padding: 140px 20px 90px; color: var(--color-text); }
 .project-detail__hero { max-width: 860px; margin-bottom: 42px; }
 .project-detail__hero > span { color: var(--color-accent); font-size: .72rem; font-weight: 800; letter-spacing: .16em; text-transform: uppercase; }
 .project-detail h1 { margin: 14px 0; font-size: clamp(3rem, 9vw, 8rem); line-height: .84; letter-spacing: -.07em; }
 .project-detail__hero p { max-width: 650px; color: var(--color-text-muted, #9aa3b2); font-size: 1.15rem; line-height: 1.45; }
-.project-gallery__main { aspect-ratio: 16/9; overflow: hidden; background: #131924; }
+.project-gallery__main { aspect-ratio: 16/9; overflow: hidden; background: var(--color-bg); border: 1px solid var(--ui-card-border); border-radius: var(--ui-radius-card); }
 .project-gallery__main img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.project-gallery__placeholder { border-radius: var(--ui-radius-card); }
 .project-gallery__thumbs { display: flex; gap: 10px; overflow-x: auto; padding-top: 12px; }
 .project-gallery__thumbs button { flex: 0 0 110px; padding: 0; border: 2px solid transparent; background: none; cursor: pointer; opacity: .55; }
 .project-gallery__thumbs button.active, .project-gallery__thumbs button:focus-visible { border-color: var(--color-accent); opacity: 1; }
@@ -18,12 +19,12 @@
 .project-detail__related { margin-top: 100px; }
 .project-detail__related h2 { font-size: 1.7rem; }
 .project-detail__related > div { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
-.project-detail__related a { position: relative; color: #fff; text-decoration: none; overflow: hidden; }
+.project-detail__related a { position: relative; color: #fff; text-decoration: none; overflow: hidden; border-radius: var(--ui-radius-card-sm); background: var(--color-bg-solid); }
 .project-detail__related img { display: block; width: 100%; aspect-ratio: 16/8; object-fit: cover; filter: brightness(.7); transition: transform .5s ease, filter .5s ease; }
 .project-detail__related a:hover img { transform: scale(1.04); filter: brightness(.9); }
 .project-detail__related span { position: absolute; left: 18px; bottom: 16px; font-size: 1.25rem; font-weight: 700; }
+.project-detail__related-placeholder { display: grid; place-items: center; aspect-ratio: 16/8; color: var(--color-text); background: linear-gradient(135deg, var(--color-bg-2), var(--color-bg-3)); font-size: 1.2rem; font-weight: 700; }
 .project-detail--empty { min-height: 70vh; display: grid; place-content: center; text-align: center; }
-@media (max-width: 800px) { .project-detail { padding: 110px 22px 70px; } .project-detail__facts { grid-template-columns: repeat(2, 1fr); } .project-detail__related > div { grid-template-columns: 1fr; } }
+@media (max-width: 800px) { .project-detail { padding: 110px 14px 70px; } .project-detail__facts { grid-template-columns: repeat(2, 1fr); } .project-detail__related > div { grid-template-columns: 1fr; } }
 @media (max-width: 480px) { .project-detail__facts { grid-template-columns: 1fr; } }
 @media (prefers-reduced-motion: reduce) { .project-detail__related img { transition: none; } }
-

--- a/my-app/src/styles/pages/ProjectsPage.css
+++ b/my-app/src/styles/pages/ProjectsPage.css
@@ -1,13 +1,13 @@
-.projects-page { max-width: 1240px; margin: 0 auto; padding: 140px 5vw 90px; color: var(--color-text); }
+.projects-page { max-width: 1240px; margin: 0 auto; padding: 140px 20px 90px; color: var(--color-text); }
 .projects-page__header { max-width: 760px; margin-bottom: 54px; }
 .projects-page__back, .project-detail__back { display: inline-block; margin-bottom: 58px; color: var(--color-text-muted, #9aa3b2); text-decoration: none; }
 .projects-page__header > span { color: var(--color-accent); font-size: .7rem; font-weight: 800; letter-spacing: .18em; }
 .projects-page h1 { margin: 14px 0; font-size: clamp(2.5rem, 7vw, 6rem); line-height: .9; letter-spacing: -.06em; }
 .projects-page__header p { max-width: 540px; color: var(--color-text-muted, #9aa3b2); font-size: 1.05rem; line-height: 1.5; }
 .projects-page__grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
-.project-index-card { color: inherit; text-decoration: none; border: 1px solid rgba(127,127,127,.22); background: rgba(255,255,255,.035); transition: transform .35s ease, border-color .35s ease; }
-.project-index-card:hover, .project-index-card:focus-visible { transform: translateY(-5px); border-color: var(--color-accent); }
-.project-index-card__media { aspect-ratio: 16/10; overflow: hidden; background: #131924; }
+.project-index-card { color: inherit; text-decoration: none; border: 1px solid var(--ui-card-border); border-radius: var(--ui-radius-card); background: var(--color-bg-solid); box-shadow: var(--ui-card-shadow); overflow: hidden; transition: transform var(--ui-transition), border-color var(--ui-transition), box-shadow var(--ui-transition); }
+.project-index-card:hover, .project-index-card:focus-visible { transform: translateY(-4px); border-color: var(--color-accent); box-shadow: var(--ui-card-shadow-hover); }
+.project-index-card__media { aspect-ratio: 16/10; overflow: hidden; background: var(--color-bg); }
 .project-index-card__media img { display: block; width: 100%; height: 100%; object-fit: cover; transition: transform .6s ease; }
 .project-index-card:hover img { transform: scale(1.04); }
 .project-index-card__body { position: relative; padding: 22px; }
@@ -15,6 +15,5 @@
 .project-index-card h2 { margin: 8px 0; font-size: 2rem; }
 .project-index-card p { max-width: 34rem; margin: 0; color: var(--color-text-muted, #9aa3b2); line-height: 1.45; }
 .project-index-card b { position: absolute; right: 22px; bottom: 22px; font-size: 1.4rem; }
-@media (max-width: 700px) { .projects-page { padding: 110px 22px 70px; } .projects-page__back { margin-bottom: 42px; } .projects-page__grid { grid-template-columns: 1fr; } }
+@media (max-width: 700px) { .projects-page { padding: 110px 14px 70px; } .projects-page__back { margin-bottom: 42px; } .projects-page__grid { grid-template-columns: 1fr; } }
 @media (prefers-reduced-motion: reduce) { .project-index-card, .project-index-card__media img { transition: none; } }
-

--- a/my-app/src/styles/pages/ProjectsPage.css
+++ b/my-app/src/styles/pages/ProjectsPage.css
@@ -1,0 +1,20 @@
+.projects-page { max-width: 1240px; margin: 0 auto; padding: 140px 5vw 90px; color: var(--color-text); }
+.projects-page__header { max-width: 760px; margin-bottom: 54px; }
+.projects-page__back, .project-detail__back { display: inline-block; margin-bottom: 58px; color: var(--color-text-muted, #9aa3b2); text-decoration: none; }
+.projects-page__header > span { color: var(--color-accent); font-size: .7rem; font-weight: 800; letter-spacing: .18em; }
+.projects-page h1 { margin: 14px 0; font-size: clamp(2.5rem, 7vw, 6rem); line-height: .9; letter-spacing: -.06em; }
+.projects-page__header p { max-width: 540px; color: var(--color-text-muted, #9aa3b2); font-size: 1.05rem; line-height: 1.5; }
+.projects-page__grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
+.project-index-card { color: inherit; text-decoration: none; border: 1px solid rgba(127,127,127,.22); background: rgba(255,255,255,.035); transition: transform .35s ease, border-color .35s ease; }
+.project-index-card:hover, .project-index-card:focus-visible { transform: translateY(-5px); border-color: var(--color-accent); }
+.project-index-card__media { aspect-ratio: 16/10; overflow: hidden; background: #131924; }
+.project-index-card__media img { display: block; width: 100%; height: 100%; object-fit: cover; transition: transform .6s ease; }
+.project-index-card:hover img { transform: scale(1.04); }
+.project-index-card__body { position: relative; padding: 22px; }
+.project-index-card__body > span { color: var(--color-accent); font-size: .7rem; text-transform: uppercase; letter-spacing: .08em; }
+.project-index-card h2 { margin: 8px 0; font-size: 2rem; }
+.project-index-card p { max-width: 34rem; margin: 0; color: var(--color-text-muted, #9aa3b2); line-height: 1.45; }
+.project-index-card b { position: absolute; right: 22px; bottom: 22px; font-size: 1.4rem; }
+@media (max-width: 700px) { .projects-page { padding: 110px 22px 70px; } .projects-page__back { margin-bottom: 42px; } .projects-page__grid { grid-template-columns: 1fr; } }
+@media (prefers-reduced-motion: reduce) { .project-index-card, .project-index-card__media img { transition: none; } }
+


### PR DESCRIPTION
## Qué cambia
- Reorganiza la landing alrededor de resultados y proyectos visuales.
- Mejora navegación desktop/mobile con overlay, Escape y cierre automático.
- Agrega catálogo público en /sites y detalle visual en /proyectos/:id.
- Añade galerías, métricas, microinteracciones y auditoría de assets.

## Validación
- npm run build ✅
- La revisión visual local quedó pendiente por conectividad del navegador integrado; este PR queda listo para generar el Preview de Cloudflare Pages.