### PR TITLE
feat: align landing navigation narrative

### DIFF
--- a/my-app/src/App.js
+++ b/my-app/src/App.js
@@ -54,9 +54,9 @@ function App({ initialLanguage }) {
     { key: 'soluciones', Component: Soluciones },
     { key: 'casos', Component: CasosEstudio },
     { key: 'testimonios', Component: Testimonios },
+    { key: 'servicios', Component: Servicios },
     { key: 'sobre-mi', Component: SobreMi },
     { key: 'portafolio', Component: Portafolio },
-    { key: 'servicios', Component: Servicios },
     { key: 'contacto', Component: Contacto },
   ];
 

--- a/my-app/src/App.test.js
+++ b/my-app/src/App.test.js
@@ -18,4 +18,21 @@ describe('App public diagnosis removal', () => {
   it('does not expose the public gracias-agenda route', () => {
     expect(appSource).not.toContain('/gracias-agenda');
   });
+
+  it('renders the landing sections in the approved narrative order', () => {
+    const sectionOrder = [
+      "{ key: 'hero', Component: HeroBanner }",
+      "{ key: 'soluciones', Component: Soluciones }",
+      "{ key: 'casos', Component: CasosEstudio }",
+      "{ key: 'testimonios', Component: Testimonios }",
+      "{ key: 'servicios', Component: Servicios }",
+      "{ key: 'sobre-mi', Component: SobreMi }",
+      "{ key: 'portafolio', Component: Portafolio }",
+      "{ key: 'contacto', Component: Contacto }"
+    ];
+    const positions = sectionOrder.map((entry) => appSource.indexOf(entry));
+
+    expect(positions.every((position) => position >= 0)).toBe(true);
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
 });

--- a/my-app/src/App.test.js
+++ b/my-app/src/App.test.js
@@ -1,5 +1,24 @@
 const fs = require('fs');
 const path = require('path');
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock('./components/HeroBanner', () => () => <header id="hero-banner" />);
+jest.mock('./components/Soluciones', () => () => <section id="soluciones" />);
+jest.mock('./components/CasosEstudio', () => () => <section id="casos-reales" />);
+jest.mock('./components/Testimonios', () => () => <section id="testimonios" />);
+jest.mock('./components/Servicios', () => () => <section id="como-trabajo" />);
+jest.mock('./components/SobreMi', () => () => <section id="sobre-mi" />);
+jest.mock('./components/Portafolio', () => () => <section id="portafolio" />);
+jest.mock('./components/Contacto', () => () => <section id="contacto" />);
+jest.mock('./components/Navegacion', () => () => null);
+jest.mock('./components/Footer', () => () => null);
+jest.mock('./components/SettingsMenu', () => () => null);
+jest.mock('./components/FloatingButton', () => () => null);
+jest.mock('./components/ChatModal', () => () => null);
 
 describe('App public diagnosis removal', () => {
   const appSource = fs.readFileSync(path.join(__dirname, 'App.js'), 'utf8');
@@ -34,5 +53,33 @@ describe('App public diagnosis removal', () => {
 
     expect(positions.every((position) => position >= 0)).toBe(true);
     expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it('renders the home sections in the approved DOM order', async () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(<App initialLanguage="es" />);
+    });
+
+    const actualOrder = Array.from(container.querySelectorAll('section[id], header[id]'))
+      .map((element) => element.id)
+      .filter((id) => ['hero-banner', 'soluciones', 'casos-reales', 'testimonios', 'como-trabajo', 'sobre-mi', 'portafolio', 'contacto'].includes(id));
+
+    expect(actualOrder).toEqual([
+      'hero-banner',
+      'soluciones',
+      'casos-reales',
+      'testimonios',
+      'como-trabajo',
+      'sobre-mi',
+      'portafolio',
+      'contacto'
+    ]);
+
+    act(() => root.unmount());
+    container.remove();
   });
 });

--- a/my-app/src/components/Contacto.js
+++ b/my-app/src/components/Contacto.js
@@ -123,7 +123,7 @@ function Contacto({ style }) {
     <AnimatedSection
       id="contacto"
       className="contacto"
-      style={{ scrollMarginTop: '60px', ...style }}
+      style={style}
       {...(prefersReducedMotion
         ? {}
         : {

--- a/my-app/src/components/Footer.js
+++ b/my-app/src/components/Footer.js
@@ -2,35 +2,13 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
+import { getNavigationContent } from '../config/navigation';
 import '../styles/components/Footer.css';
 
 function Footer() {
   const { language } = useLanguage();
 
-  const footerLinks = {
-    es: {
-      inicio: 'Inicio',
-      sobreMi: 'Sobre Mí',
-      casosReales: 'Casos reales',
-      portafolio: 'Carrera',
-      soluciones: 'Soluciones',
-      contacto: 'Contacto',
-      privacy: 'Privacidad',
-      terms: 'Términos',
-      connect: 'Conéctate conmigo en:'
-    },
-    en: {
-      inicio: 'Home',
-      sobreMi: 'About Me',
-      casosReales: 'Case studies',
-      portafolio: 'Career',
-      soluciones: 'Solutions',
-      contacto: 'Contact',
-      privacy: 'Privacy Policy',
-      terms: 'Terms of Service',
-      connect: 'Connect with me on:'
-    }
-  };
+  const footerLinks = getNavigationContent(language);
 
   const handleScrollToElement = (id) => {
     const element = document.getElementById(id);
@@ -43,17 +21,19 @@ function Footer() {
     <footer className="footer">
       <div className="footer-content">
         <div className="footer-links">
-          <Link to="/" onClick={() => handleScrollToElement('hero-banner')}><i className="fas fa-home"></i></Link>
-          <Link to="/" onClick={() => handleScrollToElement('sobre-mi')}>{footerLinks[language].sobreMi}</Link>
-          <Link to="/" onClick={() => handleScrollToElement('casos-reales')}>{footerLinks[language].casosReales}</Link>
-          <Link to="/" onClick={() => handleScrollToElement('portafolio')}>{footerLinks[language].portafolio}</Link>
-          <Link to="/" onClick={() => handleScrollToElement('soluciones')}>{footerLinks[language].soluciones}</Link>
-          <Link to="/" onClick={() => handleScrollToElement('contacto')}>{footerLinks[language].contacto}</Link>
-          <Link to="/privacy-policy">{footerLinks[language].privacy}</Link>
-          <Link to="/terms-of-service">{footerLinks[language].terms}</Link>
+          <Link to="/" onClick={() => handleScrollToElement('hero-banner')}>{footerLinks.inicio}</Link>
+          {footerLinks.primary.map((item) => (
+            <Link key={item.key} to="/" onClick={() => handleScrollToElement(item.target)}>{item.label}</Link>
+          ))}
+          {footerLinks.secondary.map((item) => (
+            <Link key={item.key} to="/" onClick={() => handleScrollToElement(item.target)}>{item.label}</Link>
+          ))}
+          <Link to="/" onClick={() => handleScrollToElement('contacto')}>{footerLinks.footerContact}</Link>
+          <Link to="/privacy-policy">{footerLinks.privacy}</Link>
+          <Link to="/terms-of-service">{footerLinks.terms}</Link>
         </div>
         <div className="footer-social">
-          <p>{footerLinks[language].connect}</p>
+          <p>{footerLinks.connect}</p>
           <div className="social-links">
             <a href="https://linkedin.com/in/elier/" target="_blank" rel="noopener noreferrer"><i className="fab fa-linkedin"></i> LinkedIn</a>
             <a href="https://github.com/elelier" target="_blank" rel="noopener noreferrer"><i className="fab fa-github"></i> GitHub</a>

--- a/my-app/src/components/Footer.test.js
+++ b/my-app/src/components/Footer.test.js
@@ -110,4 +110,25 @@ describe('Footer', () => {
 
     cleanup();
   });
+
+  it('follows the landing narrative while keeping the complete footer navigation', () => {
+    const { container, cleanup } = renderFooter('es');
+    const labels = Array.from(container.querySelectorAll('.footer-links a'))
+      .map((link) => link.textContent.trim());
+
+    expect(labels.slice(0, 9)).toEqual([
+      'Inicio',
+      'Soluciones',
+      'Casos reales',
+      'Cómo trabajo',
+      'Sobre Mí',
+      'Carrera',
+      'Contacto',
+      'Privacidad',
+      'Términos'
+    ]);
+    expect(container.textContent).not.toContain('Habilidades');
+
+    cleanup();
+  });
 });

--- a/my-app/src/components/Navegacion.js
+++ b/my-app/src/components/Navegacion.js
@@ -1,67 +1,94 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useLanguage } from '../contexts/LanguageContext';
 import { scrollIntoViewWithMotionPreference } from './utils/generalUtils';
+import { activeSectionMap, getNavigationContent, observedSectionIds } from '../config/navigation';
 import '../styles/components/Navegacion.css';
 
 function Navegacion() {
   const [menuOpen, setMenuOpen] = useState(false);
-  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [aboutOpen, setAboutOpen] = useState(false);
+  const [activeSection, setActiveSection] = useState(null);
   const { language } = useLanguage();
+  const aboutButtonRef = useRef(null);
+  const content = getNavigationContent(language);
 
-  const toggleMenu = () => {
-    setMenuOpen(!menuOpen);
-  };
-
-  const closeMenu = () => {
-    setMenuOpen(false);
-  };
-
+  const closeMenu = () => setMenuOpen(false);
 
   const handleScrollToElement = (id) => {
     const element = document.getElementById(id);
     if (element) {
       scrollIntoViewWithMotionPreference(element);
       closeMenu();
+      setAboutOpen(false);
+    }
+  };
+
+  const toggleAbout = () => setAboutOpen((current) => !current);
+
+  const handleAboutKeyDown = (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleAbout();
     }
   };
 
   useEffect(() => {
+    const observedSections = observedSectionIds
+      .map((id) => document.getElementById(id))
+      .filter(Boolean);
+
+    if (!observedSections.length || typeof window.IntersectionObserver === 'undefined') {
+      return undefined;
+    }
+
+    const observer = new window.IntersectionObserver(
+      (entries) => {
+        const visibleEntry = entries.find((entry) => entry.isIntersecting);
+        if (visibleEntry) {
+          setActiveSection(activeSectionMap[visibleEntry.target.id] || null);
+        }
+      },
+      { rootMargin: '-80px 0px -55% 0px', threshold: [0, 0.1, 0.5, 1] }
+    );
+
+    observedSections.forEach((section) => observer.observe(section));
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        if (aboutOpen) {
+          setAboutOpen(false);
+          aboutButtonRef.current?.focus();
+        } else if (menuOpen) {
+          closeMenu();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [aboutOpen, menuOpen]);
+
+  useEffect(() => {
     const handleClickOutside = (event) => {
-      // Aquí nos aseguramos que al hacer clic fuera del menú, se cierre
       if (menuOpen && !event.target.closest('.nav-content') && !event.target.closest('.menu-toggle')) {
         closeMenu();
       }
 
-      // Aquí cerramos el menú de settings si está abierto y se hace clic afuera
-      if (settingsOpen && !event.target.closest('.settings-menu') && !event.target.closest('.settings-toggle')) {
-        setSettingsOpen(false);
+      if (aboutOpen && !event.target.closest('.nav-secondary')) {
+        setAboutOpen(false);
       }
     };
 
     document.addEventListener('click', handleClickOutside);
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, [menuOpen, aboutOpen]);
 
-    return () => {
-      document.removeEventListener('click', handleClickOutside);
-    };
-  }, [menuOpen, settingsOpen]);
-
-  const navItems = {
-    es: {
-      sobreMi: 'Sobre Mí',
-      casosReales: 'Casos reales',
-      portafolio: 'Carrera',
-      soluciones: 'Soluciones',
-      contactame: 'Hablemos de tu reto',
-    },
-    en: {
-      sobreMi: 'About Me',
-      casosReales: 'Case studies',
-      portafolio: 'Career',
-      soluciones: 'Solutions',
-      contactame: 'Let’s talk about your challenge',
-    }
-  };
+  const isActive = (key) => activeSection === key;
+  const isAboutActive = isActive('sobreMi') || isActive('carrera');
 
   return (
     <nav className="navegacion" role="navigation" aria-label="Navegación principal">
@@ -71,25 +98,72 @@ function Navegacion() {
             <div className="logo">Elier Loya Mata</div>
           </Link>
         </div>
-        <button className="menu-toggle" onClick={toggleMenu} aria-label="Toggle menu">
+
+        <button
+          className="menu-toggle"
+          onClick={() => setMenuOpen((current) => !current)}
+          aria-label="Toggle menu"
+          aria-expanded={menuOpen}
+          aria-controls="primary-navigation"
+        >
           {menuOpen ? '✖' : '☰'}
         </button>
-        <ul className={`nav-links ${menuOpen ? 'open' : ''}`}>
-          <li><Link to="/" onClick={() => handleScrollToElement('hero-banner')}><i className="fas fa-home"></i></Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('sobre-mi')}>{navItems[language].sobreMi}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('casos-reales')}>{navItems[language].casosReales}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('portafolio')}>{navItems[language].portafolio}</Link></li>
-          <li><Link to="/" onClick={() => handleScrollToElement('soluciones')}>{navItems[language].soluciones}</Link></li>
+
+        <ul id="primary-navigation" className={`nav-links ${menuOpen ? 'open' : ''}`}>
+          {content.primary.map((item) => (
+            <li key={item.key}>
+              <Link
+                to="/"
+                className={isActive(item.key) ? 'is-active' : ''}
+                aria-current={isActive(item.key) ? 'location' : undefined}
+                onClick={() => handleScrollToElement(item.target)}
+              >
+                {item.label}
+              </Link>
+            </li>
+          ))}
+
+          <li className={`nav-secondary${isAboutActive ? ' is-active' : ''}`}>
+            <button
+              ref={aboutButtonRef}
+              className="nav-secondary-toggle"
+              type="button"
+              aria-haspopup="true"
+              aria-expanded={aboutOpen}
+              aria-controls="about-navigation"
+              aria-current={isAboutActive ? 'location' : undefined}
+              onClick={toggleAbout}
+              onKeyDown={handleAboutKeyDown}
+            >
+              {content.secondaryLabel}<span aria-hidden="true">⌄</span>
+            </button>
+            <ul id="about-navigation" className={`nav-secondary-menu${aboutOpen ? ' open' : ''}`}>
+              {content.secondary.map((item) => (
+                <li key={item.key}>
+                  <Link
+                    to="/"
+                    className={isActive(item.key) ? 'is-active' : ''}
+                    aria-current={isActive(item.key) ? 'location' : undefined}
+                    onClick={() => handleScrollToElement(item.target)}
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </li>
+
           <li>
             <Link
               to="/"
-              className="contact-button"
+              className={`contact-button${isActive('contact') ? ' is-active' : ''}`}
+              aria-current={isActive('contact') ? 'location' : undefined}
               onClick={() => handleScrollToElement('contacto')}
             >
-              <div className="icon-container" style={{ display: 'inline-block' }}>
+              <span className="icon-container" aria-hidden="true">
                 <i className="fas fa-comment-dots"></i>
-              </div>
-              {navItems[language].contactame}
+              </span>
+              {content.contact}
             </Link>
           </li>
         </ul>

--- a/my-app/src/components/Navegacion.js
+++ b/my-app/src/components/Navegacion.js
@@ -9,8 +9,10 @@ function Navegacion() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [aboutOpen, setAboutOpen] = useState(false);
   const [activeSection, setActiveSection] = useState(null);
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth <= 830);
   const { language } = useLanguage();
   const aboutButtonRef = useRef(null);
+  const menuToggleRef = useRef(null);
   const content = getNavigationContent(language);
 
   const closeMenu = () => setMenuOpen(false);
@@ -32,6 +34,12 @@ function Navegacion() {
       toggleAbout();
     }
   };
+
+  useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth <= 830);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
 
   useEffect(() => {
     const observedSections = observedSectionIds
@@ -64,6 +72,7 @@ function Navegacion() {
           aboutButtonRef.current?.focus();
         } else if (menuOpen) {
           closeMenu();
+          menuToggleRef.current?.focus();
         }
       }
     };
@@ -91,7 +100,7 @@ function Navegacion() {
   const isAboutActive = isActive('sobreMi') || isActive('carrera');
 
   return (
-    <nav className="navegacion" role="navigation" aria-label="Navegación principal">
+    <nav className="navegacion" role="navigation" aria-label={content.navLabel}>
       <div className="nav-content">
         <div className="logo-container">
           <Link to="/" onClick={() => handleScrollToElement('hero-banner')}>
@@ -100,16 +109,17 @@ function Navegacion() {
         </div>
 
         <button
+          ref={menuToggleRef}
           className="menu-toggle"
           onClick={() => setMenuOpen((current) => !current)}
-          aria-label="Toggle menu"
+          aria-label={menuOpen ? content.menuClose : content.menuOpen}
           aria-expanded={menuOpen}
           aria-controls="primary-navigation"
         >
           {menuOpen ? '✖' : '☰'}
         </button>
 
-        <ul id="primary-navigation" className={`nav-links ${menuOpen ? 'open' : ''}`}>
+        <ul id="primary-navigation" hidden={isMobile && !menuOpen} className={`nav-links ${menuOpen ? 'open' : ''}`}>
           {content.primary.map((item) => (
             <li key={item.key}>
               <Link
@@ -137,7 +147,12 @@ function Navegacion() {
             >
               {content.secondaryLabel}<span aria-hidden="true">⌄</span>
             </button>
-            <ul id="about-navigation" className={`nav-secondary-menu${aboutOpen ? ' open' : ''}`}>
+            <ul
+              id="about-navigation"
+              hidden={!aboutOpen}
+              aria-hidden={!aboutOpen}
+              className={`nav-secondary-menu${aboutOpen ? ' open' : ''}`}
+            >
               {content.secondary.map((item) => (
                 <li key={item.key}>
                   <Link

--- a/my-app/src/components/Navegacion.test.js
+++ b/my-app/src/components/Navegacion.test.js
@@ -246,6 +246,47 @@ describe('Navegacion', () => {
     Object.values(sections).forEach((section) => section.remove());
   });
 
+  it('clears every active navigation state when returning from Soluciones to Hero', () => {
+    const observed = [];
+    const OriginalObserver = window.IntersectionObserver;
+    window.IntersectionObserver = class {
+      constructor(callback) {
+        this.callback = callback;
+      }
+
+      observe(element) {
+        observed.push({ element, observer: this });
+      }
+
+      disconnect() {}
+    };
+
+    const hero = document.createElement('header');
+    hero.id = 'hero-banner';
+    const solutions = document.createElement('section');
+    solutions.id = 'soluciones';
+    document.body.append(hero, solutions);
+
+    const { container, cleanup } = renderNavegacion('es');
+    const trigger = (id) => {
+      const entry = observed.find(({ element }) => element.id === id);
+      expect(entry).toBeTruthy();
+      act(() => entry.observer.callback([{ target: document.getElementById(id), isIntersecting: true }]));
+    };
+
+    trigger('soluciones');
+    expect(findLinkByText(container, 'Soluciones').getAttribute('aria-current')).toBe('location');
+
+    trigger('hero-banner');
+    expect(container.querySelector('[aria-current="location"]')).toBeNull();
+    expect(container.querySelector('.is-active')).toBeNull();
+
+    cleanup();
+    window.IntersectionObserver = OriginalObserver;
+    hero.remove();
+    solutions.remove();
+  });
+
   it('restores focus to the mobile menu button after Escape closes the menu', () => {
     const { container, cleanup } = renderNavegacion('es');
     const menuToggle = container.querySelector('.menu-toggle');

--- a/my-app/src/components/Navegacion.test.js
+++ b/my-app/src/components/Navegacion.test.js
@@ -6,6 +6,8 @@ import { LanguageContext } from '../contexts/LanguageContext';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+const originalInnerWidth = window.innerWidth;
+
 const renderNavegacion = (language = 'es') => {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -34,10 +36,12 @@ const findLinkByText = (container, text) => Array.from(container.querySelectorAl
 
 describe('Navegacion', () => {
   beforeEach(() => {
+    window.innerWidth = 390;
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
   afterEach(() => {
+    window.innerWidth = originalInnerWidth;
     jest.restoreAllMocks();
     document.body.innerHTML = '';
   });
@@ -153,7 +157,10 @@ describe('Navegacion', () => {
     expect(moreButton.getAttribute('aria-haspopup')).toBe('true');
     expect(moreButton.getAttribute('aria-controls')).toBe('about-navigation');
     expect(moreButton.getAttribute('aria-expanded')).toBe('false');
+    expect(moreButton.getAttribute('aria-label')).toBeNull();
     expect(container.querySelector('#about-navigation')).toBeTruthy();
+    expect(container.querySelector('#about-navigation').hidden).toBe(true);
+    expect(container.querySelector('.nav-links').hidden).toBe(true);
     expect(container.textContent).toContain('Sobre Mí');
     expect(container.textContent).toContain('Carrera');
 
@@ -196,22 +203,80 @@ describe('Navegacion', () => {
       }
     };
 
-    const testimonios = document.createElement('section');
-    testimonios.id = 'testimonios';
-    document.body.appendChild(testimonios);
+    const sections = ['testimonios', 'sobre-mi', 'portafolio', 'contacto'].reduce((acc, id) => {
+      const section = document.createElement('section');
+      section.id = id;
+      document.body.appendChild(section);
+      acc[id] = section;
+      return acc;
+    }, {});
     const { container, cleanup } = renderNavegacion('es');
 
-    act(() => {
-      const entry = observed.find(({ element }) => element.id === 'testimonios');
-      entry.observer.callback([{ target: testimonios, isIntersecting: true }]);
-    });
+    const trigger = (id) => {
+      const entry = observed.find(({ element }) => element.id === id);
+      expect(entry).toBeTruthy();
+      act(() => {
+        entry.observer.callback([{ target: sections[id], isIntersecting: true }]);
+      });
+    };
 
+    trigger('testimonios');
     const casesLink = findLinkByText(container, 'Casos reales');
     expect(casesLink.getAttribute('aria-current')).toBe('location');
     expect(casesLink.classList.contains('is-active')).toBe(true);
 
+    trigger('sobre-mi');
+    const aboutButton = container.querySelector('.nav-secondary-toggle');
+    const aboutLink = findLinkByText(container, 'Sobre Mí');
+    expect(aboutButton.getAttribute('aria-current')).toBe('location');
+    expect(aboutLink.getAttribute('aria-current')).toBe('location');
+
+    trigger('portafolio');
+    const careerLink = findLinkByText(container, 'Carrera');
+    expect(aboutButton.getAttribute('aria-current')).toBe('location');
+    expect(careerLink.getAttribute('aria-current')).toBe('location');
+
+    trigger('contacto');
+    const contactLink = findLinkByText(container, 'Hablemos de tu reto');
+    expect(contactLink.getAttribute('aria-current')).toBe('location');
+
     cleanup();
+    expect(observed.every(({ observer }) => observer.disconnected)).toBe(true);
     window.IntersectionObserver = OriginalObserver;
-    testimonios.remove();
+    Object.values(sections).forEach((section) => section.remove());
+  });
+
+  it('restores focus to the mobile menu button after Escape closes the menu', () => {
+    const { container, cleanup } = renderNavegacion('es');
+    const menuToggle = container.querySelector('.menu-toggle');
+    const navLinks = container.querySelector('.nav-links');
+
+    act(() => {
+      menuToggle.click();
+    });
+    expect(navLinks.hidden).toBe(false);
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(navLinks.hidden).toBe(true);
+    expect(document.activeElement).toBe(menuToggle);
+    cleanup();
+  });
+
+  it('keeps navigation labels and menu actions accessible in Spanish and English', () => {
+    ['es', 'en'].forEach((language) => {
+      const { container, cleanup } = renderNavegacion(language);
+      const nav = container.querySelector('nav');
+      const menuToggle = container.querySelector('.menu-toggle');
+
+      expect(nav.getAttribute('aria-label')).toBe(language === 'es' ? 'Navegación principal' : 'Main navigation');
+      expect(menuToggle.getAttribute('aria-label')).toBe(language === 'es' ? 'Abrir menú' : 'Open menu');
+      act(() => menuToggle.click());
+      expect(menuToggle.getAttribute('aria-label')).toBe(language === 'es' ? 'Cerrar menú' : 'Close menu');
+
+      cleanup();
+    });
   });
 });

--- a/my-app/src/components/Navegacion.test.js
+++ b/my-app/src/components/Navegacion.test.js
@@ -139,4 +139,79 @@ describe('Navegacion', () => {
 
     cleanup();
   });
+
+  it('uses the decision path and groups personal context under Más sobre mí', () => {
+    const { container, cleanup } = renderNavegacion('es');
+    const links = Array.from(container.querySelectorAll('.nav-links > li > a, .nav-links > li > button'))
+      .map((element) => element.textContent.replace('⌄', '').trim())
+      .filter(Boolean);
+
+    expect(links).toEqual(['Soluciones', 'Casos reales', 'Cómo trabajo', 'Más sobre mí', 'Hablemos de tu reto']);
+    expect(container.querySelector('.nav-links .fa-home')).toBeNull();
+
+    const moreButton = container.querySelector('.nav-secondary-toggle');
+    expect(moreButton.getAttribute('aria-haspopup')).toBe('true');
+    expect(moreButton.getAttribute('aria-controls')).toBe('about-navigation');
+    expect(moreButton.getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('#about-navigation')).toBeTruthy();
+    expect(container.textContent).toContain('Sobre Mí');
+    expect(container.textContent).toContain('Carrera');
+
+    cleanup();
+  });
+
+  it('opens Más sobre mí with keyboard and closes it with Escape while restoring focus', () => {
+    const { container, cleanup } = renderNavegacion('es');
+    const moreButton = container.querySelector('.nav-secondary-toggle');
+
+    act(() => {
+      moreButton.focus();
+      moreButton.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    expect(moreButton.getAttribute('aria-expanded')).toBe('true');
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(moreButton.getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement).toBe(moreButton);
+
+    cleanup();
+  });
+
+  it('maps Testimonios to Casos reales in the active navigation state', () => {
+    const observed = [];
+    const OriginalObserver = window.IntersectionObserver;
+    window.IntersectionObserver = class {
+      constructor(callback) {
+        this.callback = callback;
+      }
+
+      observe(element) {
+        observed.push({ element, observer: this });
+      }
+
+      disconnect() {
+        this.disconnected = true;
+      }
+    };
+
+    const testimonios = document.createElement('section');
+    testimonios.id = 'testimonios';
+    document.body.appendChild(testimonios);
+    const { container, cleanup } = renderNavegacion('es');
+
+    act(() => {
+      const entry = observed.find(({ element }) => element.id === 'testimonios');
+      entry.observer.callback([{ target: testimonios, isIntersecting: true }]);
+    });
+
+    const casesLink = findLinkByText(container, 'Casos reales');
+    expect(casesLink.getAttribute('aria-current')).toBe('location');
+    expect(casesLink.classList.contains('is-active')).toBe(true);
+
+    cleanup();
+    window.IntersectionObserver = OriginalObserver;
+    testimonios.remove();
+  });
 });

--- a/my-app/src/components/Servicios.js
+++ b/my-app/src/components/Servicios.js
@@ -60,7 +60,7 @@ function Servicios({ style }) {
   const t = content[language] || content.es;
 
   return (
-    <section id="como-trabajo" className="servicios" style={{ scrollMarginTop: '96px', ...style }}>
+    <section id="como-trabajo" className="servicios" style={style}>
       <div className="servicios-shell">
         <div className="servicios-header">
           <span>{language === 'es' ? 'Método de colaboración' : 'Collaboration method'}</span>

--- a/my-app/src/config/navigation.js
+++ b/my-app/src/config/navigation.js
@@ -11,6 +11,9 @@ export const navigationConfig = {
       { key: 'carrera', label: 'Carrera', target: 'portafolio' }
     ],
     contact: 'Hablemos de tu reto',
+    navLabel: 'Navegación principal',
+    menuOpen: 'Abrir menú',
+    menuClose: 'Cerrar menú',
     footerContact: 'Contacto',
     inicio: 'Inicio',
     privacy: 'Privacidad',
@@ -29,6 +32,9 @@ export const navigationConfig = {
       { key: 'carrera', label: 'Career', target: 'portafolio' }
     ],
     contact: "Let’s talk about your challenge",
+    navLabel: 'Main navigation',
+    menuOpen: 'Open menu',
+    menuClose: 'Close menu',
     footerContact: 'Contact',
     inicio: 'Home',
     privacy: 'Privacy Policy',

--- a/my-app/src/config/navigation.js
+++ b/my-app/src/config/navigation.js
@@ -46,6 +46,7 @@ export const navigationConfig = {
 export const getNavigationContent = (language) => navigationConfig[language] || navigationConfig.es;
 
 export const activeSectionMap = {
+  'hero-banner': null,
   soluciones: 'soluciones',
   'casos-reales': 'casosReales',
   testimonios: 'casosReales',

--- a/my-app/src/config/navigation.js
+++ b/my-app/src/config/navigation.js
@@ -1,0 +1,52 @@
+export const navigationConfig = {
+  es: {
+    primary: [
+      { key: 'soluciones', label: 'Soluciones', target: 'soluciones' },
+      { key: 'casosReales', label: 'Casos reales', target: 'casos-reales' },
+      { key: 'comoTrabajo', label: 'Cómo trabajo', target: 'como-trabajo' }
+    ],
+    secondaryLabel: 'Más sobre mí',
+    secondary: [
+      { key: 'sobreMi', label: 'Sobre Mí', target: 'sobre-mi' },
+      { key: 'carrera', label: 'Carrera', target: 'portafolio' }
+    ],
+    contact: 'Hablemos de tu reto',
+    footerContact: 'Contacto',
+    inicio: 'Inicio',
+    privacy: 'Privacidad',
+    terms: 'Términos',
+    connect: 'Conéctate conmigo en:'
+  },
+  en: {
+    primary: [
+      { key: 'soluciones', label: 'Solutions', target: 'soluciones' },
+      { key: 'casosReales', label: 'Case studies', target: 'casos-reales' },
+      { key: 'comoTrabajo', label: 'How I work', target: 'como-trabajo' }
+    ],
+    secondaryLabel: 'More about me',
+    secondary: [
+      { key: 'sobreMi', label: 'About Me', target: 'sobre-mi' },
+      { key: 'carrera', label: 'Career', target: 'portafolio' }
+    ],
+    contact: "Let’s talk about your challenge",
+    footerContact: 'Contact',
+    inicio: 'Home',
+    privacy: 'Privacy Policy',
+    terms: 'Terms of Service',
+    connect: 'Connect with me on:'
+  }
+};
+
+export const getNavigationContent = (language) => navigationConfig[language] || navigationConfig.es;
+
+export const activeSectionMap = {
+  soluciones: 'soluciones',
+  'casos-reales': 'casosReales',
+  testimonios: 'casosReales',
+  'como-trabajo': 'comoTrabajo',
+  'sobre-mi': 'sobreMi',
+  portafolio: 'carrera',
+  contacto: 'contact'
+};
+
+export const observedSectionIds = Object.keys(activeSectionMap);

--- a/my-app/src/styles/components/Navegacion.css
+++ b/my-app/src/styles/components/Navegacion.css
@@ -1,183 +1,180 @@
-@import '../index.css'; 
+@import '../index.css';
 
+:root {
+  --header-scroll-offset: 80px;
+}
 
-/* Estilos para la barra de navegación principal */
+section[id] {
+  scroll-margin-top: var(--header-scroll-offset);
+}
+
 .navegacion {
-  position: fixed; /* Asegura que la barra esté siempre visible */
+  position: fixed;
   width: 100%;
   height: 60px;
   z-index: 1000;
-  background-color: var(--color-bg); /* Color sólido */
-  opacity: 0.7; /* Asegura que no sea transparente */
+  background-color: var(--color-bg);
+  opacity: 0.7;
   transition: background-color 0.3s ease-in-out, opacity 0.5s ease, transform 0.5s ease;
 }
 
-.navegacion:hover{
-  opacity: 1; /* Asegura que no sea transparente */
-  transition: background-color 0.3s ease-in-out, opacity 0.5s ease, transform 0.5s ease;
+.navegacion:hover,
+.navegacion:focus-within {
+  opacity: 1;
 }
 
-
-/* Estilo para el logo */
-.logo-container {
-  flex-shrink: 0; /* Evita que el logo se reduzca en tamaño */
-  z-index: 100; /* Para asegurarte de que esté por encima de otros elementos */
-}
-
-/* Estilo para el logo dentro de un enlace */
-.logo {
-  font-size: 20px;
-  font-weight: bold;
-  color: var(--color-text);
-  transition: color 0.3s ease;
-  text-decoration: none; /* Elimina el subrayado */
-}
-
-.logo:hover {
-  transform: scale(1.01) !important;
-  color: var(--color-accent);
-  text-decoration: none; /* Elimina el subrayado también en hover */
-  transition: transform 0.5s ease;
-}
-
-/* Asegura que el contenedor también no tenga subrayado si es necesario */
-.logo-container a {
-  text-decoration: none; /* Elimina el subrayado para enlaces dentro del contenedor */
-}
-
-
-/* Contenido de la barra de navegación */
 .nav-content {
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 0 5%;
-  height: 60px; /* Ajusta la altura según lo que necesites */
+  height: 60px;
 }
-/* Estilo de los enlaces de navegación en la barra principal */
+
+.logo-container {
+  flex-shrink: 0;
+  z-index: 100;
+}
+
+.logo-container a {
+  text-decoration: none;
+}
+
+.logo {
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--color-text);
+  transition: color 0.3s ease, transform 0.3s ease;
+}
+
+.logo:hover {
+  transform: scale(1.01);
+  color: var(--color-accent);
+}
+
 .nav-links {
-  position: absolute;
   display: flex;
-  justify-content:center; /* Centra los enlaces y distribuye el espacio equitativamente */
-  align-items: center; /* Alinea verticalmente los enlaces */
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
   list-style: none;
   margin: 0;
   padding: 0;
-  width: 100%; /* Asegura que el contenedor ocupe el 100% del ancho disponible */
 }
-
 
 .nav-links li {
-  margin-left: 15px; /* Espacio entre los elementos de la lista */
+  position: relative;
 }
 
-.nav-links a {
+.nav-links a,
+.nav-secondary-toggle {
   color: var(--color-text);
   text-decoration: none;
+  font: inherit;
   font-weight: 510;
-  transition: color 0.3s ease;
+  white-space: nowrap;
+  transition: color 0.3s ease, transform 0.3s ease;
 }
 
-.nav-links a:hover {
+.nav-secondary-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  padding: 6px 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.nav-secondary-toggle span {
+  font-size: 0.9em;
+  transition: transform 0.2s ease;
+}
+
+.nav-secondary-toggle[aria-expanded='true'] span {
+  transform: rotate(180deg);
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible,
+.nav-secondary-toggle:hover,
+.nav-secondary-toggle:focus-visible,
+.nav-links a.is-active,
+.nav-secondary.is-active > .nav-secondary-toggle {
   color: var(--color-accent);
-  transform: scale(1.05) !important;
-  transition: transform 0.5s ease;
-
 }
 
-.nav-links i:hover {
-  color: var(--color-accent);
-  transform: scale(1.05) !important;
-  transition: transform 0.5s ease;
-
+.nav-links a:focus-visible,
+.nav-secondary-toggle:focus-visible,
+.menu-toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
 }
-/* Estilo para el enlace "Contacto" */
-.nav-contact {
-  position: relative; /* Asegura que este elemento no se vea afectado por los estilos globales */
+
+.nav-secondary-menu {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  min-width: 170px;
+  margin: 0;
+  padding: 8px;
+  list-style: none;
+  background: var(--color-bg);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.nav-secondary-menu.open {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.nav-secondary-menu a {
+  display: block;
+  padding: 9px 12px;
+  border-radius: 8px;
+}
+
+.nav-secondary-menu a:hover,
+.nav-secondary-menu a:focus-visible {
+  background: rgba(var(--color-accent-rgb), 0.12);
 }
 
 .contact-button {
-  position: relative;
-  z-index: 9999;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 7px 12px;
+  border: none;
+  border-radius: 50px;
   background: linear-gradient(135deg, #a80c9b, #7bcff8, #00cc99);
   background-size: 300% 300%;
   color: white !important;
-  border: none;
-  border-radius: 50px;
-  padding: 5px 15px;
-  display: flex;
-  font-size: 18px;
-  justify-content: center;
-  align-items: center;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
-  transition: transform 0.3s ease, background-color 0.3s ease;
-  cursor: pointer;
-  letter-spacing: 1px;
+  font-size: 14px;
   font-weight: bold !important;
-  animation: gradientBG 10s ease infinite !important;
+  letter-spacing: 0;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  animation: gradientBG 10s ease infinite;
 }
 
-
-.contact-button:hover {
-  transform: translateY(-2px) !important;
+.contact-button:hover,
+.contact-button:focus-visible {
   color: white !important;
+  transform: translateY(-2px);
   box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3);
-  animation: gradientBG 18s ease infinite;
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5) !important; /* Para el botón */
-}
-
-/* Sombra para el ícono al hacer hover en el botón */
-.contact-button:hover .icon-container::before {
-  opacity: 1; /* Muestra la sombra al hacer hover */
 }
 
 .icon-container {
-  position: relative;
   display: inline-block;
-  padding-right: 5px;
 }
 
-.icon-container::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5); /* Color de la sombra */
-  border-radius: 50%; /* Bordes redondeados */
-  z-index: -1; /* Detrás del ícono */
-  filter: blur(4px); /* Desenfoque de la sombra */
-  opacity: 0; /* Inicialmente invisible */
-  transition: opacity 0.3s ease; /* Transición suave */
-}
-
-.contact-button:hover i {
-  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5) !important; /* Asegúrate que se aplique aquí también */
-}
-
-.contact-button:active {
-  transform: scale(0.95) !important;
-  transform: translateY(4px) !important;
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3), inset 0 -1px 2px rgba(0, 0, 0, 0.2);
-  animation: none;
-}
-
-/* Animación de parpadeo */
-@keyframes blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
-}
-
-/* Animación del gradiente */
-@keyframes gradientBG {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-}
-
-/* Estilos generales para el botón de menú */
-/* Estilos generales para el botón de menú */
 .menu-toggle {
   display: none;
   cursor: pointer;
@@ -185,166 +182,111 @@
   background: none;
   border: none;
   color: var(--color-text);
-  margin-left: -5px;
   z-index: 1001;
   position: relative;
   font-weight: bold;
 }
 
-.menu-toggle:hover {
-  /* Elimina el efecto de escala para evitar problemas de deformación */
-  color: var(--color-accent); /* Cambia el color al pasar el ratón */
+@keyframes gradientBG {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }
 
-/* Ajustes específicos para dispositivos móviles */
 @media (max-width: 830px) {
   .navegacion {
-    opacity: 1; 
+    opacity: 1;
   }
-  
-  .logo-container {
-    position: relative;
-    left: 50%;
-    transform: translateX(-50%);
-    top: 25x; /* Ajusta según lo que necesites */
-    z-index: 100; /* Para asegurarte de que esté por encima de otros elementos */
+
+  .nav-content {
+    justify-content: center;
   }
-  
+
   .logo {
-    font-size: 30px;
-  }  
+    font-size: 20px;
+  }
+
   .menu-toggle {
     display: block;
     position: fixed;
-  }
-
-  .contact-button {
-    display: none; /* Oculta el botón en su ubicación normal */
+    top: 14px;
+    left: 15px;
   }
 
   .nav-links {
     position: fixed;
     top: 0;
-    right: -100%;
-    width: 45%;
+    right: 0;
+    width: min(78%, 320px);
     height: 100vh;
-    background-color: rgba(18, 30, 52, 0.95);
+    padding: 90px 24px 32px;
+    box-sizing: border-box;
+    background: var(--color-bg);
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    transition: left 0.3s ease;
+    align-items: stretch;
+    justify-content: flex-start;
+    gap: 18px;
+    overflow-y: auto;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    box-shadow: -12px 0 28px rgba(0, 0, 0, 0.25);
   }
 
   .nav-links.open {
-    left: 0; /* Mostrar el menú cuando se abre */
-    padding-top: 40px;
-    background-color: var(--color-bg);
-
-  }
-  .nav-links li {
-    margin-bottom: 45px; /* Espacio entre enlaces */
-    margin-left: -20px;
-    list-style: none;
+    transform: translateX(0);
   }
 
-  .nav-links a {
-    color: var(--color-text);
-    text-decoration: none;
-    font-size: 25px;
-    padding-left: 20px;
-    display: block;
+  .nav-links li,
+  .nav-links a,
+  .nav-secondary-toggle {
     width: 100%;
-    transition: background 0.3s ease;
-  }
-  
-  .nav-links a:hover {
-    transform: scale(1.1);
-    color: var(--color-accent); /* Cambia color a azul */
-    }
-
-  .nav-links a:active {
-    transform: scale(0.95);
-    }
-  
-
-  .nav-links .contact-button {
-    display: block; /* Mostrar el botón dentro del menú desplegable */
-    margin: 0px 0;
-    font-size: 18px;
-    position: static; /* Elimina el posicionamiento fijo para que fluya dentro del menú */
-    width: auto;
-    text-align: center;
   }
 
-  .nav-links .contact-button {
-    margin-left: 20px;
-  }
-
-  .fa-comment-dot {
-    margin-right: 8px
-  }
-
-}
-@media (max-width: 666px) {
-  .logo {
-    font-size: 20px;
-    }
-
-  .nav-links .contact-button {
-    font-size: 15px;
-  }
-
-  .nav-links {
-    position: fixed;
-    top: 0;
-    right: -100%;
-    width: 70%;
-    height: 100vh;
-    background-color: rgba(18, 30, 52, 0.95);
-    flex-direction: column;
+  .nav-links a,
+  .nav-secondary-toggle {
+    display: flex;
     align-items: center;
-    justify-content: center;
-    transition: left 0.3s ease;
+    justify-content: space-between;
+    box-sizing: border-box;
+    padding: 12px 8px;
+    font-size: 21px;
   }
-  
-  
+
+  .nav-secondary-menu {
+    position: static;
+    min-width: 0;
+    margin: 4px 0 0 12px;
+    padding: 0 0 0 12px;
+    border: 0;
+    border-left: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 0;
+    box-shadow: none;
+    opacity: 1;
+    pointer-events: none;
+    transform: none;
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.25s ease;
+  }
+
+  .nav-secondary-menu.open {
+    pointer-events: auto;
+    max-height: 140px;
+  }
+
+  .nav-secondary-menu a {
+    font-size: 18px;
+  }
+
+  .contact-button {
+    margin-top: 12px;
+    justify-content: center !important;
+    font-size: 17px !important;
+  }
 }
 
-
-/* CSS */
-.language-toggle {
-  background: none;
-  border: none;
-  color: var(--color-text);
-  font-size: 12px;
-  cursor: pointer;
-  padding: 5px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  transition: transform 0.3s ease, color 0.3s ease;
+@media (max-width: 400px) {
+  .nav-links {
+    width: 82%;
+  }
 }
-
-/* Estilo del triángulo debajo del texto */
-.triangle {
-  width: 0;
-  height: 0;
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-top: 6px solid currentColor; /* El triángulo usa el color del botón */
-  margin-top: 5px; /* Espacio entre las siglas y el triángulo */
-  transition: transform 0.3s ease, border-color 0.3s ease; /* Transición para la escala y color */
-}
-
-/* Efecto hover para cambiar color y escalar un poco */
-.language-toggle:hover {
-  transform: scale(1.1);
-  color: var(--color-accent); /* Cambia color a azul */
-}
-
-/* Efecto clic para reducir el tamaño temporalmente */
-.language-toggle:active {
-  transform: scale(0.95);
-  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.3), inset 0 -1px 2px rgba(0, 0, 0, 0.2); /* Sombra interior */
-}
-

--- a/my-app/src/styles/components/Navegacion.css
+++ b/my-app/src/styles/components/Navegacion.css
@@ -24,6 +24,7 @@ section[id] {
 }
 
 .nav-content {
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -60,6 +61,14 @@ section[id] {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+@media (min-width: 831px) {
+  .nav-links {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+  }
 }
 
 .nav-links[hidden],

--- a/my-app/src/styles/components/Navegacion.css
+++ b/my-app/src/styles/components/Navegacion.css
@@ -62,6 +62,11 @@ section[id] {
   padding: 0;
 }
 
+.nav-links[hidden],
+.nav-secondary-menu[hidden] {
+  display: none !important;
+}
+
 .nav-links li {
   position: relative;
 }


### PR DESCRIPTION
## Summary

- Reordered the landing DOM to follow Hero → Solutions → Case studies → Testimonials → How I work → About Me → Career → Contact.
- Rebuilt desktop and mobile navigation around the decision path: Solutions → Case studies → How I work → persistent CTA.
- Added accessible More about me dropdown/expandable group, active section state including explicit Hero clearing, shared navigation data, and centralized anchor offset.
- Updated footer ordering and regression coverage.

## Validation

- `npm test -- --runInBand --watchAll=false` — 31 suites, 105 tests passed.
- `npm run build` — production build succeeded.
- `git diff --check` — clean.
- Smoke validation completed in the preview by moving from Hero to Solutions and back to Hero; active navigation changed to Solutions and then cleared.
- Visual validation completed at desktop 1440×900 and mobile 390×844, including dropdown and expandable mobile group.

No merge or deploy performed.